### PR TITLE
Support text/plain podcast transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 8.21
 -----
 - Fix New Episodes push notifications still arriving after turning off Profile → Settings → Notifications → New Episodes [#5039](https://github.com/Automattic/pocket-casts-ios/pull/5039)
+- Fix transcripts not showing for podcasts whose feeds serve them as plain text, such as those hosted on Transistor [#5055](https://github.com/Automattic/pocket-casts-ios/pull/5055)
 
 8.20
 -----

--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptFormatTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptFormatTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import PocketCastsDataModel
+@testable import podcasts
+
+final class TranscriptFormatTests: XCTestCase {
+
+    private func transcript(type: String) -> Episode.Metadata.Transcript {
+        Episode.Metadata.Transcript(url: "https://example.com/transcript", type: type, language: nil)
+    }
+
+    func testPlainTextIsASupportedFormat() {
+        XCTAssertEqual(transcript(type: "text/plain").transcriptFormat, .textPlain)
+    }
+
+    func testMediaTypeParametersAreIgnored() {
+        XCTAssertEqual(transcript(type: "text/plain; charset=utf-8").transcriptFormat, .textPlain)
+        XCTAssertEqual(transcript(type: "Text/VTT").transcriptFormat, .vtt)
+    }
+
+    func testUnknownFormatHasNoMatch() {
+        XCTAssertNil(transcript(type: "application/pdf").transcriptFormat)
+    }
+
+    func testBestTranscriptPrefersTimedFormatsOverPlainText() {
+        let plainText = transcript(type: "text/plain")
+        let vtt = transcript(type: "text/vtt")
+
+        XCTAssertEqual(TranscriptFormat.bestTranscript(from: [plainText, vtt])?.transcriptFormat, .vtt)
+    }
+
+    func testBestTranscriptUsesPlainTextWhenItIsTheOnlyOne() {
+        let plainText = transcript(type: "text/plain")
+
+        XCTAssertEqual(TranscriptFormat.bestTranscript(from: [plainText])?.transcriptFormat, .textPlain)
+    }
+}

--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
@@ -46,6 +46,16 @@ final class TranscriptManagerTests: XCTestCase {
         }
     }
 
+    class PlainTextMockShowCoordinator: MockShowCoordinator {
+        override func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> EpisodeTranscriptData {
+            guard let transcriptURL = Bundle(for: Self.self).url(forResource: "sample", withExtension: "txt") else {
+                return (transcripts: [], hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
+            }
+            let transcript = Episode.Metadata.Transcript(url: transcriptURL.absoluteString, type: "text/plain", language: nil)
+            return (transcripts: [transcript], hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
+        }
+    }
+
     func testLoadingTranscript() async throws {
         let mockShowCoordinator = MockShowCoordinator()
         let manager = TranscriptManager(episodeUUID: UUID().uuidString, podcastUUID: UUID().uuidString, showCoordinator: mockShowCoordinator)
@@ -79,5 +89,14 @@ final class TranscriptManagerTests: XCTestCase {
         } catch {
             XCTAssertTrue(error is TranscriptError)
         }
+    }
+
+    func testLoadingPlainTextTranscript() async throws {
+        let manager = TranscriptManager(episodeUUID: UUID().uuidString, podcastUUID: UUID().uuidString, showCoordinator: PlainTextMockShowCoordinator())
+
+        let model = try await manager.loadTranscript()
+
+        XCTAssertTrue(model.attributedText.string.contains("Today I'm speaking with Daniel Kokotajlo."))
+        XCTAssertTrue(model.cues.isEmpty)
     }
 }

--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptModelFilterTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptModelFilterTests.swift
@@ -319,10 +319,20 @@ final class TranscriptModelFilterTests: XCTestCase {
         }
 
         let text = model.attributedText.string
-        XCTAssertTrue(text.contains("Luisa Rodriguez: Today I'm speaking with Daniel Kokotajlo."))
-        XCTAssertTrue(text.contains("Daniel Kokotajlo: Thanks for having me."))
+        XCTAssertEqual(text, "Luisa Rodriguez: Today I'm speaking with Daniel Kokotajlo.\nDaniel Kokotajlo: Thanks for having me.")
         XCTAssertTrue(model.cues.isEmpty)
         XCTAssertFalse(model.hasJavascript)
+    }
+
+    func testPlainTextCollapsesBlankLinesAndCarriageReturns() throws {
+        let transcript = "First paragraph.  \r\n\r\n\r\nSecond  paragraph.\r\n"
+
+        guard let model = TranscriptModel.makeModel(from: transcript, format: .textPlain) else {
+            XCTFail("Model should be created")
+            return
+        }
+
+        XCTAssertEqual(model.attributedText.string, "First paragraph.\nSecond paragraph.")
     }
 
     func testPlainTextEmpty() throws {

--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptModelFilterTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptModelFilterTests.swift
@@ -305,4 +305,27 @@ final class TranscriptModelFilterTests: XCTestCase {
         XCTAssertFalse(text.contains("42"))
         XCTAssertEqual(model.cues.count, 1)
     }
+
+    func testPlainText() throws {
+        let transcript = """
+        Luisa Rodriguez: Today I'm speaking with Daniel Kokotajlo.
+
+        Daniel Kokotajlo: Thanks for having me.
+        """
+
+        guard let model = TranscriptModel.makeModel(from: transcript, format: .textPlain) else {
+            XCTFail("Model should be created")
+            return
+        }
+
+        let text = model.attributedText.string
+        XCTAssertTrue(text.contains("Luisa Rodriguez: Today I'm speaking with Daniel Kokotajlo."))
+        XCTAssertTrue(text.contains("Daniel Kokotajlo: Thanks for having me."))
+        XCTAssertTrue(model.cues.isEmpty)
+        XCTAssertFalse(model.hasJavascript)
+    }
+
+    func testPlainTextEmpty() throws {
+        XCTAssertNil(TranscriptModel.makeModel(from: "   \n  ", format: .textPlain))
+    }
 }

--- a/PocketCastsTests/Tests/Player/Transcripts/sample.txt
+++ b/PocketCastsTests/Tests/Player/Transcripts/sample.txt
@@ -1,0 +1,5 @@
+Luisa Rodriguez: Today I'm speaking with Daniel Kokotajlo.
+
+Last year, Daniel and his colleagues published a narrative forecast that was read by millions of people.
+
+Daniel Kokotajlo: Thanks for having me. I'm very excited to chat.

--- a/podcasts/TranscriptFilter.swift
+++ b/podcasts/TranscriptFilter.swift
@@ -22,6 +22,13 @@ struct ComposeFilter: TranscriptFilter {
         RegexFilter.fullStopEndofCueFilter
     ])
 
+    static let plainTextFilter = ComposeFilter(filters: [
+        RegexFilter.carriageReturnFilter,
+        RegexFilter.emptySpacesAtEndOfLinesFilter,
+        RegexFilter.doubleOrMoreSpacesFilter,
+        RegexFilter.doubleOrMoreEmptyLinesFilter,
+    ])
+
     static let htmlFilter = ComposeFilter(filters: [
         RegexFilter.breakLineFilter,
         RegexFilter.htmlParagraphFilter,
@@ -81,6 +88,8 @@ extension RegexFilter {
     static let doubleOrMoreSpacesFilter = RegexFilter(pattern: "[ ]+", replacement: " ")
     // Double or more lines
     static let doubleOrMoreEmptyLinesFilter = RegexFilter(pattern: "[\\n]+", replacement: "\n")
+    // Normalize Windows and classic Mac line endings
+    static let carriageReturnFilter = RegexFilter(pattern: "\\r\\n?", replacement: "\n")
     // </p> filter
     static let htmlParagraphFilter = RegexFilter(pattern: "</p>", replacement: "\n")
 }

--- a/podcasts/TranscriptFormat.swift
+++ b/podcasts/TranscriptFormat.swift
@@ -6,6 +6,7 @@ public enum TranscriptFormat: String, CaseIterable {
     case srt = "application/srt"
     case vtt = "text/vtt"
     case textHTML = "text/html"
+    case textPlain = "text/plain"
     case jsonPodcastIndex = "application/json"
 
     public var fileExtension: String {
@@ -16,6 +17,8 @@ public enum TranscriptFormat: String, CaseIterable {
             return "vtt"
         case .textHTML:
             return "html"
+        case .textPlain:
+            return "txt"
         case .jsonPodcastIndex:
             return "json"
         }
@@ -29,17 +32,19 @@ public enum TranscriptFormat: String, CaseIterable {
             return Set([self.rawValue])
         case .textHTML:
             return Set([self.rawValue])
+        case .textPlain:
+            return Set([self.rawValue])
         case .jsonPodcastIndex:
             return Set([self.rawValue])
         }
     }
 
-    // Transcript formats we support in order of priority of use
-    public static let supportedFormats: [TranscriptFormat] = [.vtt, .jsonPodcastIndex, .srt, .textHTML]
+    // Transcript formats we support in order of priority of use. Untimed formats come last.
+    public static let supportedFormats: [TranscriptFormat] = [.vtt, .jsonPodcastIndex, .srt, .textHTML, .textPlain]
 
     public static func bestTranscript(from available: [Episode.Metadata.Transcript]) -> Episode.Metadata.Transcript? {
         for format in Self.supportedFormats {
-            if let transcript = available.first(where: { format.possibleTypes.contains($0.type)}) {
+            if let transcript = available.first(where: { format.possibleTypes.contains($0.normalizedType)}) {
                 return transcript
             }
         }
@@ -48,7 +53,13 @@ public enum TranscriptFormat: String, CaseIterable {
 }
 
 extension Episode.Metadata.Transcript {
+    /// The media type without any parameters, lowercased. For example, `Text/Plain; charset=utf-8` reads as `text/plain`.
+    public var normalizedType: String {
+        guard let mediaType = type.split(separator: ";", maxSplits: 1).first else { return type }
+        return mediaType.trimmingCharacters(in: .whitespaces).lowercased()
+    }
+
     public var transcriptFormat: TranscriptFormat? {
-        TranscriptFormat.allCases.first { $0.possibleTypes.contains(type) }
+        TranscriptFormat.allCases.first { $0.possibleTypes.contains(normalizedType) }
     }
 }

--- a/podcasts/TranscriptFormat.swift
+++ b/podcasts/TranscriptFormat.swift
@@ -56,7 +56,7 @@ extension Episode.Metadata.Transcript {
     /// The media type without any parameters, lowercased. For example, `Text/Plain; charset=utf-8` reads as `text/plain`.
     public var normalizedType: String {
         guard let mediaType = type.split(separator: ";", maxSplits: 1).first else { return type }
-        return mediaType.trimmingCharacters(in: .whitespaces).lowercased()
+        return mediaType.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
     public var transcriptFormat: TranscriptFormat? {

--- a/podcasts/TranscriptModel.swift
+++ b/podcasts/TranscriptModel.swift
@@ -33,7 +33,8 @@ struct TranscriptModel: Sendable {
             return TranscriptModel(attributedText: NSAttributedString(string: filteredText), cues: [], type: format.rawValue, hasJavascript: transcriptText.contains("<script type=\"text/javascript\">"))
         }
         if format == .textPlain {
-            return TranscriptModel(attributedText: NSAttributedString(string: trimmedTranscript), cues: [], type: format.rawValue, hasJavascript: false)
+            let filteredText = ComposeFilter.plainTextFilter.filter(trimmedTranscript).trim()
+            return TranscriptModel(attributedText: NSAttributedString(string: filteredText), cues: [], type: format.rawValue, hasJavascript: false)
         }
         let subtitles: Subtitles? = {
             do {

--- a/podcasts/TranscriptModel.swift
+++ b/podcasts/TranscriptModel.swift
@@ -32,6 +32,9 @@ struct TranscriptModel: Sendable {
             let filteredText = ComposeFilter.htmlFilter.filter(transcriptText).trim()
             return TranscriptModel(attributedText: NSAttributedString(string: filteredText), cues: [], type: format.rawValue, hasJavascript: transcriptText.contains("<script type=\"text/javascript\">"))
         }
+        if format == .textPlain {
+            return TranscriptModel(attributedText: NSAttributedString(string: trimmedTranscript), cues: [], type: format.rawValue, hasJavascript: false)
+        }
         let subtitles: Subtitles? = {
             do {
                 if format == .jsonPodcastIndex {


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-910

Feeds hosted on Transistor advertise their transcripts as `text/plain` (for example every episode of *The 80,000 Hours Podcast*). `TranscriptFormat` only knew about `text/vtt`, `application/srt`, `application/json` and `text/html`, so `transcriptFormat` resolved to `nil` and the player showed a "this format is not supported" error instead of the transcript.

Adds `text/plain` as a supported format, rendered as untimed text like the existing HTML transcripts (no cues, so no karaoke highlighting — plain text carries no timings). It sits last in `supportedFormats`, so a timed transcript is still preferred whenever a feed offers one. Media type matching now also ignores parameters and case, so `text/plain; charset=utf-8` resolves the same way.

## To test

1. Search for and follow *The 80,000 Hours Podcast*.
2. Open any episode and tap the transcript button in the player.
3. The transcript is displayed. On trunk this shows "Sorry, we can't display this transcript" with a `text/plain` format error.
4. Open an episode of a podcast with a VTT transcript (most shows) and confirm transcripts still highlight along with playback.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.