### PR TITLE
Report a storage error when playback fails on a full disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - Fix New Episodes push notifications still arriving after turning off Profile → Settings → Notifications → New Episodes [#5039](https://github.com/Automattic/pocket-casts-ios/pull/5039)
 - Fix transcripts not showing for podcasts whose feeds serve them as plain text, such as those hosted on Transistor [#5055](https://github.com/Automattic/pocket-casts-ios/pull/5055)
+- Playback failures caused by a full disk now report a storage error instead of asking you to check your internet connection [#5056](https://github.com/Automattic/pocket-casts-ios/pull/5056)
 
 8.20
 -----

--- a/PocketCastsTests/Tests/Player/PlaybackStorageErrorTests.swift
+++ b/PocketCastsTests/Tests/Player/PlaybackStorageErrorTests.swift
@@ -1,0 +1,41 @@
+import AVFoundation
+import XCTest
+@testable import podcasts
+
+final class PlaybackStorageErrorTests: XCTestCase {
+
+    func testCocoaOutOfSpaceErrorIsDetected() {
+        let error = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteOutOfSpaceError)
+
+        XCTAssertTrue(error.isOutOfStorage)
+    }
+
+    func testDiskFullErrorIsDetected() {
+        let error = NSError(domain: AVFoundationErrorDomain, code: AVError.Code.diskFull.rawValue)
+
+        XCTAssertTrue(error.isOutOfStorage)
+    }
+
+    func testUnderlyingOutOfSpaceErrorIsDetected() {
+        let posixError = NSError(domain: NSPOSIXErrorDomain, code: Int(ENOSPC))
+        let mediaError = NSError(domain: AVFoundationErrorDomain, code: AVError.Code.unknown.rawValue, userInfo: [NSUnderlyingErrorKey: posixError])
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: [NSUnderlyingErrorKey: mediaError])
+
+        XCTAssertTrue(error.isOutOfStorage)
+    }
+
+    func testNetworkErrorIsNotReportedAsOutOfStorage() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+
+        XCTAssertFalse(error.isOutOfStorage)
+    }
+
+    func testNotEnoughStorageDoesNotBlameTheInternetConnection() {
+        let error = PlaybackManager.PlaybackError.notEnoughStorage(logMessage: nil)
+
+        XCTAssertEqual(error.userMessage, L10n.playerErrorNotEnoughStorage)
+        XCTAssertEqual(error.shortUserMessage, L10n.playerErrorShortNotEnoughStorage)
+        XCTAssertNotEqual(error.userMessage, L10n.playerErrorInternetConnection)
+        XCTAssertEqual(error.analyticsDetail, "not_enough_storage")
+    }
+}

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -353,6 +353,12 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         // Give priority to player item error
         let playerError: Error? = (player.currentItem?.error ?? player.error)
         let playerNSError = playerError as? NSError
+        let logMessage = "AVPlayerItemStatusFailed on currentItem: \(playerErrorMessage) - \(playerItemErrorMessage)"
+
+        if let playerNSError, playerNSError.isOutOfStorage {
+            PlaybackManager.shared.playbackDidFail(error: .notEnoughStorage(logMessage: logMessage))
+            return true
+        }
 
         if let playerNSError, playerNSError.domain == NSURLErrorDomain, playerNSError.code != NSURLErrorNotConnectedToInternet,
            let episodeUuid {
@@ -360,7 +366,6 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
                 return false
             }
         }
-        let logMessage = "AVPlayerItemStatusFailed on currentItem: \(playerErrorMessage) - \(playerItemErrorMessage)"
         var error: PlaybackManager.PlaybackError = .playbackError(logMessage: logMessage, isLocalFile: isPlayingLocalFile)
         if let playerNSError,
            playerNSError.domain == NSURLErrorDomain {
@@ -1025,5 +1030,25 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
     func setVolume(_ volume: Float) {
         player?.volume = volume
+    }
+}
+
+extension NSError {
+    /// Whether this error, or any error underlying it, reports that the device has run out of storage.
+    var isOutOfStorage: Bool {
+        var error: NSError? = self
+        var depth = 0
+        while let current = error, depth < 10 {
+            depth += 1
+            switch (current.domain, current.code) {
+            case (NSCocoaErrorDomain, NSFileWriteOutOfSpaceError),
+                 (NSPOSIXErrorDomain, Int(ENOSPC)),
+                 (AVFoundationErrorDomain, AVError.Code.diskFull.rawValue):
+                return true
+            default:
+                error = current.userInfo[NSUnderlyingErrorKey] as? NSError
+            }
+        }
+        return false
     }
 }

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -957,7 +957,11 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
             let error = notification.userInfo?[AVPlayerItemFailedToPlayToEndTimeErrorKey] as? Error
             let errorMessage = error?.localizedDescription ?? "Unknown item did fail to finish error"
-            PlaybackManager.shared.playbackDidFail(error: .playbackError(logMessage: errorMessage, isLocalFile: isPlayingLocalFile))
+            if let nsError = error as? NSError, nsError.isOutOfStorage {
+                PlaybackManager.shared.playbackDidFail(error: .notEnoughStorage(logMessage: errorMessage))
+            } else {
+                PlaybackManager.shared.playbackDidFail(error: .playbackError(logMessage: errorMessage, isLocalFile: isPlayingLocalFile))
+            }
         }
 
         playStalledObserver = nc.addObserver(forName: NSNotification.Name.AVPlayerItemPlaybackStalled, object: nil, queue: nil) { [weak self] _ in

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1191,6 +1191,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         case episodeNotAvailable(errorCode: Int, logMessage: String?)
         case fileCorrupted(logMessage: String?)
         case chromecastError(logMessage: String?)
+        case notEnoughStorage(logMessage: String?)
         case playbackError(logMessage: String?, isLocalFile: Bool)
 
         var userMessage: String {
@@ -1203,6 +1204,8 @@ class PlaybackManager: ServerPlaybackDelegate {
                 return L10n.playerErrorCorruptedFile
             case .chromecastError:
                 return L10n.chromecastError
+            case .notEnoughStorage:
+                return L10n.playerErrorNotEnoughStorage
             case .playbackError(_, let isLocalFile):
                 return isLocalFile ? L10n.playerErrorCorruptedFile : L10n.playerErrorInternetConnection
             }
@@ -1218,6 +1221,8 @@ class PlaybackManager: ServerPlaybackDelegate {
                 return L10n.playerErrorCorruptedFile
             case .chromecastError:
                 return L10n.chromecastError
+            case .notEnoughStorage:
+                return L10n.playerErrorShortNotEnoughStorage
             case .playbackError:
                 return L10n.playerErrorShortPlaybackError
             }
@@ -1262,6 +1267,8 @@ class PlaybackManager: ServerPlaybackDelegate {
                 return logMessage
             case .chromecastError(let logMessage):
                 return logMessage
+            case .notEnoughStorage(let logMessage):
+                return logMessage
             case .playbackError(let logMessage, _):
                 return logMessage
             }
@@ -1281,6 +1288,8 @@ class PlaybackManager: ServerPlaybackDelegate {
                 return "file_corrupted"
             case .chromecastError:
                 return "chromecast_error"
+            case .notEnoughStorage:
+                return "not_enough_storage"
             case .playbackError:
                 return "playback_error"
             }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6139,6 +6139,12 @@
 /* Generic error used when playback fails. */
 "player_error_short_playback_error" = "Playback failed, please try again";
 
+/* Error used when playback fails because the device has run out of storage. Streaming needs free disk space for the playback buffer. */
+"player_error_not_enough_storage" = "Your device is out of storage. Free up some space and try again.";
+
+/* Short version of the error used when playback fails because the device has run out of storage. */
+"player_error_short_not_enough_storage" = "Device storage is full";
+
 /* tv app home tab */
 "tv_tab_home" = "Home";
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-865

AVPlayer needs free disk space for its streaming buffer, so streaming fails when the device runs out of storage. `checkIfPlayerFailed()` only classified `NSURLErrorDomain` errors, so a disk-full failure fell through to the generic `.playbackError`, whose message for a streamed episode is "Check your Internet connection and try again" — sending people to debug their network while the real problem is storage. The download path already reports a storage error correctly, which is why the two disagreed.

Adds a `.notEnoughStorage` playback error, reported when the failure (or anything in its `NSUnderlyingError` chain) is `AVError.diskFull`, `NSFileWriteOutOfSpaceError`, or POSIX `ENOSPC`. It carries its own copy and its own `not_enough_storage` analytics detail, so these stop being counted as network failures.

Note: I could not verify on a device which of those codes iOS actually surfaces without filling a real disk, so the check matches all three across the underlying-error chain rather than keying on one. The classification branch itself is covered only indirectly — the unit tests cover the error matching and the message it maps to.

## To test

1. Fill the device's storage until only a small amount remains (< 100 MB free).
2. Open Pocket Casts and stream (don't download) any episode.
3. The error now reads "Your device is out of storage. Free up some space and try again." instead of "Check your Internet connection and try again."
4. Free up space, confirm streaming works again.
5. Turn on airplane mode and stream an episode — the offline error is unchanged.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.