### PR TITLE
Keep the download task id of an in-flight download

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -857,6 +857,12 @@ class EpisodeDataManager {
         save(fields: fields, values: values, dbQueue: dbQueue)
     }
 
+    func saveEpisode(downloadTaskId: String?, episode: Episode, dbQueue: PCDBQueue) {
+        episode.downloadTaskId = downloadTaskId
+
+        save(fieldName: "downloadTaskId", value: DBUtils.replaceNilWithNull(value: downloadTaskId), episodeId: episode.id, dbQueue: dbQueue)
+    }
+
     func saveEpisode(downloadStatus: DownloadStatus, sizeInBytes: Int64, downloadTaskId: String?, episode: Episode, dbQueue: PCDBQueue) {
         episode.episodeStatus = downloadStatus.rawValue
         episode.sizeInBytes = sizeInBytes

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
@@ -319,6 +319,12 @@ class UserEpisodeDataManager {
         save(fields: fields, values: values, dbQueue: dbQueue)
     }
 
+    func saveEpisode(downloadTaskId: String?, episode: UserEpisode, dbQueue: PCDBQueue) {
+        episode.downloadTaskId = downloadTaskId
+
+        save(fieldName: "downloadTaskId", value: DBUtils.replaceNilWithNull(value: downloadTaskId), episodeId: episode.id, dbQueue: dbQueue)
+    }
+
     func saveEpisode(uploadStatus: UploadStatus, episode: UserEpisode, dbQueue: PCDBQueue) {
         episode.uploadStatus = uploadStatus.rawValue
 

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -782,6 +782,14 @@ public class DataManager {
         }
     }
 
+    public func saveEpisode(downloadTaskId: String?, episode: BaseEpisode) {
+        if let episode = episode as? Episode {
+            episodeManager.saveEpisode(downloadTaskId: downloadTaskId, episode: episode, dbQueue: dbQueue)
+        } else if let episode = episode as? UserEpisode {
+            userEpisodeManager.saveEpisode(downloadTaskId: downloadTaskId, episode: episode, dbQueue: dbQueue)
+        }
+    }
+
     public func saveEpisode(downloadStatus: DownloadStatus, sizeInBytes: Int64, downloadTaskId: String?, episode: BaseEpisode) {
         if let episode = episode as? Episode {
             episodeManager.saveEpisode(downloadStatus: downloadStatus, sizeInBytes: sizeInBytes, downloadTaskId: downloadTaskId, episode: episode, dbQueue: dbQueue)

--- a/PocketCastsTests/Tests/Utilities/DownloadManagerStuckDownloadsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/DownloadManagerStuckDownloadsTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import podcasts
+import PocketCastsDataModel
+
+final class DownloadManagerStuckDownloadsTests: DBTestCase {
+
+    override func tearDown() {
+        super.tearDown()
+
+        let semaphore = DispatchSemaphore(value: 0)
+        Task {
+            await downloadManager.cancelAllTasks()
+            downloadManager.clearEpisodeCache()
+            semaphore.signal()
+        }
+        _ = semaphore.wait(timeout: .now() + 5.seconds)
+    }
+
+    func testClearStuckDownloadsKeepsRecentlyQueuedEpisode() async throws {
+        queueEpisode(lastDownloadAttemptDate: Date())
+
+        await downloadManager.clearStuckDownloads()
+
+        let saved = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertEqual(saved.downloadTaskId, episode.uuid, "A download that hasn't created its task yet should not be treated as stuck")
+        XCTAssertEqual(saved.episodeStatus, DownloadStatus.queued.rawValue)
+    }
+
+    func testClearStuckDownloadsClearsEpisodeWithoutRecentAttempt() async throws {
+        queueEpisode(lastDownloadAttemptDate: Date().addingTimeInterval(-1.hour))
+
+        await downloadManager.clearStuckDownloads()
+
+        let saved = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertNil(saved.downloadTaskId)
+        XCTAssertEqual(saved.episodeStatus, DownloadStatus.notDownloaded.rawValue)
+    }
+
+    func testPerformDownloadRestoresClearedDownloadTaskId() async throws {
+        queueEpisode(lastDownloadAttemptDate: Date())
+
+        // Simulate `clearStuckDownloads()` running while the download was still being prepared
+        dataManager.saveEpisode(downloadStatus: .notDownloaded, downloadTaskId: nil, episode: episode)
+        XCTAssertNil(dataManager.findBaseEpisode(downloadTaskId: episode.uuid))
+
+        await downloadManager.performDownload(
+            episode: episode,
+            url: try XCTUnwrap(episode.downloadUrl),
+            previousDownloadFailed: false,
+            fireNotification: false,
+            autoDownloadStatus: .notSpecified,
+            retryWithoutUserAgent: false
+        )
+
+        let saved = try XCTUnwrap(dataManager.findBaseEpisode(downloadTaskId: episode.uuid))
+        XCTAssertEqual(saved.uuid, episode.uuid, "The delegate callbacks look episodes up by downloadTaskId, so it has to match the running task")
+    }
+
+    private func queueEpisode(lastDownloadAttemptDate: Date) {
+        episode.episodeStatus = DownloadStatus.queued.rawValue
+        episode.downloadTaskId = episode.uuid
+        episode.lastDownloadAttemptDate = lastDownloadAttemptDate
+        dataManager.save(episode: episode)
+    }
+}

--- a/podcasts/DownloadManager+SessionManagement.swift
+++ b/podcasts/DownloadManager+SessionManagement.swift
@@ -53,6 +53,8 @@ extension DownloadManager {
         }
     }
 
+    private static let inFlightDownloadGracePeriod: TimeInterval = 1.minute
+
     func clearStuckDownloads() async {
         let episodesWithDownloadIds = dataManager.findEpisodesWhereNotNull(propertyName: "downloadTaskId")
 
@@ -76,6 +78,8 @@ extension DownloadManager {
 
         for episodeUuid in episodeUuids {
             guard let episode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else { continue }
+
+            if let lastAttempt = episode.lastDownloadAttemptDate, Date().timeIntervalSince(lastAttempt) < Self.inFlightDownloadGracePeriod { continue }
 
             let downloadStatus: DownloadStatus = episode.downloaded(pathFinder: self) ? .downloaded : .notDownloaded
             dataManager.saveEpisode(downloadStatus: downloadStatus, downloadTaskId: nil, episode: episode)

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -579,6 +579,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         let isOnUnexpensiveConnection = NetworkUtils.shared.isConnectedToUnexpensiveConnection()
         let networkDescription = isOnUnexpensiveConnection ? "unexpensive connection" : "expensive connection"
         FileLog.shared.addMessage("DownloadManager: Downloading episode \(episode.displayableTitle()), autoDownloadStatus: \(autoDownloadStatus), previousDownloadFailed: \(previousDownloadFailed), \(userAgentDescription), session: \(sessionDescription), network: \(networkDescription)")
+        dataManager.saveEpisode(downloadTaskId: episode.uuid, episode: episode)
         resumeDownload(tempFilePath: tempFilePath, session: sessionToUse, request: request, previousDownloadFailed: previousDownloadFailed, taskId: episode.uuid, estimatedBytes: episode.sizeInBytes, retryWithoutUserAgent: retryWithoutUserAgent)
 
         if fireNotification { NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloadStatusChanged, object: episode.uuid) }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-867

Episodes auto-added to Up Next sometimes stayed at "not downloaded" forever, with no error — even though the download really ran and received data.

`addToQueue` writes `episode.downloadTaskId` as soon as an episode is queued, but the real `URLSessionDownloadTask` is only created later, after `updatePodcastIfRequired` returns (seconds to minutes on a background-refresh launch). `clearStuckDownloads()` treats "has a `downloadTaskId` but no live task" as stale and nulls the column, so when it ran inside that window it wiped the mapping — and `resumeDownload()` never wrote it back, it only set `taskDescription` on the task. From then on `episodeForTask` looked the episode up by a `downloadTaskId` that no longer matched anything, and every callback bailed out, including `didFinishDownloadingTo`, whose temporary file iOS deletes as soon as it returns.

Two changes:

- `performDownload` re-asserts `downloadTaskId` right before the task is created, so the lookup used by the delegate callbacks is correct no matter what happened while the download was being prepared. This also stops `clearStuckDownloads()` from cancelling the live task for an episode it can no longer resolve.
- `clearStuckDownloads()` skips episodes whose download was attempted in the last minute, closing the remaining window between it reading the episode list and the task actually being created.

The new `DataManager.saveEpisode(downloadTaskId:episode:)` writes only that column, so re-asserting it doesn't disturb the episode's download status (which matters for episodes being buffered for streaming).

## To test

The race is timing-dependent, so the regression tests are the reliable check: `DownloadManagerStuckDownloadsTests` fails on trunk and passes here.

1. Enable Settings > Auto Download > Up Next.
2. Play an episode so new episodes get added to Up Next, and background the app so a background refresh triggers a launch.
3. Episodes added to Up Next download to completion rather than staying at "not downloaded".
4. Start a download, force-quit the app mid-download, relaunch: the download resumes or is re-queued as before.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.