### PR TITLE
Keep portrait video inside the player artwork area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 8.21
 -----
 - Fix New Episodes push notifications still arriving after turning off Profile → Settings → Notifications → New Episodes [#5039](https://github.com/Automattic/pocket-casts-ios/pull/5039)
+- Fix portrait video episodes overflowing the player artwork area, overlapping the controls and episode title [#5058](https://github.com/Automattic/pocket-casts-ios/pull/5058)
 
 8.20
 -----

--- a/podcasts/FloatingVideoView.swift
+++ b/podcasts/FloatingVideoView.swift
@@ -12,9 +12,10 @@ class FloatingVideoView: UIView {
         }
     }
 
+    private var videoWidthConstraint: NSLayoutConstraint!
     private var videoHeightConstraint: NSLayoutConstraint!
-    private var videoHeightSet = false
-    private var lastWidthLayedOut: CGFloat = 0
+    private var videoSize: CGSize?
+    private var lastSizeLayedOut: CGSize = .zero
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -31,24 +32,20 @@ class FloatingVideoView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        if lastWidthLayedOut == bounds.width { return }
+        if lastSizeLayedOut == bounds.size { return }
 
-        lastWidthLayedOut = bounds.width
-        videoHeightSet = false
+        lastSizeLayedOut = bounds.size
+        updateVideoViewSize()
     }
 
     private func setupView() {
         backgroundColor = UIColor.clear
 
         videoView.videoSizeKnown = { [weak self] videoSize in
-            guard let strongSelf = self, !strongSelf.videoHeightSet else { return }
+            guard let strongSelf = self, strongSelf.videoSize != videoSize else { return }
 
-            strongSelf.videoHeightSet = true
-
-            let aspectRatio = videoSize.height / videoSize.width
-            let currentWidth = strongSelf.videoView.bounds.width
-            let newHeight = aspectRatio * currentWidth
-            strongSelf.videoHeightConstraint.constant = newHeight
+            strongSelf.videoSize = videoSize
+            strongSelf.updateVideoViewSize()
         }
 
         // setup shadow
@@ -71,13 +68,28 @@ class FloatingVideoView: UIView {
         addSubview(shadowView)
         addSubview(videoView)
 
+        videoWidthConstraint = videoView.widthAnchor.constraint(equalToConstant: bounds.width)
         videoHeightConstraint = videoView.heightAnchor.constraint(equalToConstant: bounds.height)
         NSLayoutConstraint.activate([
-            videoView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            videoView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            videoView.centerXAnchor.constraint(equalTo: centerXAnchor),
             videoView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            videoWidthConstraint,
             videoHeightConstraint
         ])
         shadowView.anchorToAllSidesOf(view: videoView)
+    }
+
+    private func updateVideoViewSize() {
+        guard bounds.width > 0, bounds.height > 0 else { return }
+
+        let fittedSize: CGSize
+        if let videoSize, videoSize.width > 0, videoSize.height > 0 {
+            fittedSize = AVMakeRect(aspectRatio: videoSize, insideRect: bounds).size
+        } else {
+            fittedSize = bounds.size
+        }
+
+        videoWidthConstraint.constant = fittedSize.width
+        videoHeightConstraint.constant = fittedSize.height
     }
 }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-938

`FloatingVideoView` always stretched the video to the full width of its container and derived the height from the video's aspect ratio. That works for landscape videos, but a portrait video (e.g. 1080×1920) ends up ~1.8× taller than the square artwork area the player reserves for it, so it overflowed and broke the player layout.

The video is now aspect-fitted inside the container (`AVMakeRect`), so it always stays within the artwork area regardless of orientation, and it is re-fitted when either the container size or the video size changes rather than only once per width.

## To test

1. Subscribe to [Understanding Wine with Austin Beeman (Video)](https://pca.st/podcast/9792c300-2cd2-012e-09cc-00163e1b201c).
2. Play a portrait episode, e.g. "Wine is the Taste of Culture and History".
3. Open the full screen player: the video is letterboxed inside the artwork area and the rest of the player layout (episode title, controls) is unaffected.
4. Play the landscape control episode "Natural Wine in Rias Baixas" and confirm it still fills the width as before.
5. Rotate the device and re-open the player to confirm the video re-fits correctly.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
