### PR TITLE
Fix cast button color in the fullscreen video player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix New Episodes push notifications still arriving after turning off Profile → Settings → Notifications → New Episodes [#5039](https://github.com/Automattic/pocket-casts-ios/pull/5039)
 - Fix transcripts not showing for podcasts whose feeds serve them as plain text, such as those hosted on Transistor [#5055](https://github.com/Automattic/pocket-casts-ios/pull/5055)
 - Playback failures caused by a full disk now report a storage error instead of asking you to check your internet connection [#5056](https://github.com/Automattic/pocket-casts-ios/pull/5056)
+- Fix the Chromecast button being invisible in the fullscreen video player [#5060](https://github.com/Automattic/pocket-casts-ios/pull/5060)
 
 8.20
 -----

--- a/podcasts/Common Components/View Controllers/PCViewController.swift
+++ b/podcasts/Common Components/View Controllers/PCViewController.swift
@@ -61,11 +61,10 @@ class PCViewController: SimpleNotificationsViewController {
         if supportsGoogleCast {
             let castButton = PCGoogleCastButton(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
             castButton.addTarget(self, action: #selector(castButtonTapped), for: .touchUpInside)
-            if useTransparentNavigationBarAppearance {
-                if !LiquidGlass.isEnabled {
-                    FakeNavBarButton.applyStyle(to: castButton)
-                }
-                // On Liquid Glass, the bar's default tint already gives the cast button proper contrast.
+            if LiquidGlass.isEnabled {
+                castButton.tintColor = .label
+            } else if useTransparentNavigationBarAppearance {
+                FakeNavBarButton.applyStyle(to: castButton)
             } else {
                 castButton.tintColor = navIconsColor ?? AppTheme.navBarIconsColor()
             }

--- a/podcasts/Google Cast/UI/PCGoogleCastButton.swift
+++ b/podcasts/Google Cast/UI/PCGoogleCastButton.swift
@@ -20,9 +20,6 @@ class PCGoogleCastButton: UIButton {
     }
 
     func setup() {
-        if LiquidGlass.isEnabled {
-            tintColor = .label
-        }
         updateForCurrentState()
         NotificationCenter.default.addObserver(self, selector: #selector(stateDidChange), name: Constants.Notifications.googleCastStatusChanged, object: nil)
     }

--- a/podcasts/VideoViewController.swift
+++ b/podcasts/VideoViewController.swift
@@ -9,28 +9,41 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     var willAttachPlayer: (() -> Void)?
     var willDeattachPlayer: (() -> Void)?
 
+    private var controlsTintColor: UIColor { ThemeColor.contrast01(for: .extraDark) }
+
     @IBOutlet var routePickerView: PCRoutePickerView! {
         didSet {
-            routePickerView.tintColor = ThemeColor.contrast01(for: .extraDark)
+            routePickerView.tintColor = controlsTintColor
             routePickerView.activeTintColor = ThemeColor.primaryIcon01Active(for: .extraDark)
             routePickerView.backgroundColor = UIColor.clear
         }
     }
 
-    @IBOutlet var fillScreenBtn: UIButton!
+    @IBOutlet var closeBtn: UIButton! {
+        didSet {
+            closeBtn.tintColor = controlsTintColor
+        }
+    }
+
+    @IBOutlet var fillScreenBtn: UIButton! {
+        didSet {
+            fillScreenBtn.tintColor = controlsTintColor
+        }
+    }
 
     @IBOutlet var closeFileStackView: UIStackView!
     @IBOutlet var playPauseBtn: PlayPauseButton! {
         didSet {
             playPauseBtn.backgroundColor = UIColor.clear
             playPauseBtn.circleColor = UIColor.clear
-            playPauseBtn.playButtonColor = ThemeColor.contrast01(for: .extraDark)
+            playPauseBtn.playButtonColor = controlsTintColor
         }
     }
 
     @IBOutlet var skipForwardBtn: SkipButton! {
         didSet {
             skipForwardBtn.skipBack = false
+            skipForwardBtn.tintColor = controlsTintColor
             skipForwardBtn.longPressed = { [weak self] in
                 self?.skipForwardLongPressed()
             }
@@ -40,6 +53,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     @IBOutlet var skipBackBtn: SkipButton! {
         didSet {
             skipBackBtn.skipBack = true
+            skipBackBtn.tintColor = controlsTintColor
         }
     }
 
@@ -87,14 +101,24 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
         }
     }
 
-    @IBOutlet var pipButton: UIButton!
-
-    @IBOutlet var airplayButton: UIButton!
+    @IBOutlet var pipButton: UIButton! {
+        didSet {
+            pipButton.tintColor = controlsTintColor
+        }
+    }
 
     #if APPCLIP
-    @IBOutlet var castButton: UIButton!
+    @IBOutlet var castButton: UIButton! {
+        didSet {
+            castButton.tintColor = controlsTintColor
+        }
+    }
     #else
-    @IBOutlet var castButton: PCGoogleCastButton!
+    @IBOutlet var castButton: PCGoogleCastButton! {
+        didSet {
+            castButton.tintColor = controlsTintColor
+        }
+    }
     #endif
 
     private var pipController: AVPictureInPictureController?

--- a/podcasts/VideoViewController.xib
+++ b/podcasts/VideoViewController.xib
@@ -12,6 +12,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="VideoViewController" customModule="podcasts" customModuleProvider="target">
             <connections>
                 <outlet property="castButton" destination="DOV-qE-ZNr" id="Pfp-XB-yJD"/>
+                <outlet property="closeBtn" destination="1pC-PM-r7d" id="Rk6-Nd-8tV"/>
                 <outlet property="closeFileStackView" destination="yW4-dK-d0d" id="Lc9-Rp-2xN"/>
                 <outlet property="closeToSafeTopConstraint" destination="aWx-SG-wH6" id="SBI-GQ-fG8"/>
                 <outlet property="closeToViewTopConstraint" destination="MTO-yh-Zcf" id="FEh-jc-9Kl"/>


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-940

`PCGoogleCastButton.setup()` forced `tintColor = .label` on Liquid Glass so the icon contrasts with the navigation bar. `setup()` runs from `didMoveToSuperview`, so it also overrode the tint of the cast button in the fullscreen video player — whose chrome is always dark — and with a light theme the cast icon rendered black on top of the video.

- The Liquid Glass nav bar tint moved to `PCViewController`, where the nav bar button is actually built, so the button no longer overrides its host's tint.
- Every control in the fullscreen video player is now tinted explicitly with `ThemeColor.contrast01(for: .extraDark)` instead of relying on hardcoded white in the XIB, so they're all driven by one value.
- All of the icons involved (`close`, `pip`, `video-expand`, `video-collapse`, `nav_cast_*`) were verified to be template images, so the tint is actually applied.
- Removed the unused, unconnected `airplayButton` outlet.

## To test

1. On iOS 26, set the app to a light theme (Settings → Appearance → Light).
2. Play a video episode and open the fullscreen video player.
3. Confirm the Chromecast icon is white, matching the close, fill screen, picture in picture and AirPlay icons.
4. Repeat with a dark theme and confirm all icons are still white.
5. Open a screen with a Chromecast button in the navigation bar (e.g. a podcast page, and the Discover tab) and confirm the cast icon still has correct contrast against the bar in both light and dark themes.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
