### PR TITLE
Use v4 Discover content endpoints

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -61,16 +61,16 @@ public class DiscoverServerHandler: DiscoverServerHandling {
             switch self {
             case .discover:
                 if FeatureFlag.recommendations.enabled {
-                    contentPath.append("/content_v3.json")
+                    contentPath.append("/content_v4.json")
                 } else {
                     contentPath.append("/content_v2.json")
                 }
             case .search:
-                contentPath.append("/content_v3_search.json")
+                contentPath.append("/content_v4_search.json")
             case .signedIn:
-                contentPath.append("/content_v3_logged_in.json")
+                contentPath.append("/content_v4_logged_in.json")
             case .signedOut:
-                contentPath.append("/content_v3_logged_out.json")
+                contentPath.append("/content_v4_logged_out.json")
             }
 
             return contentPath


### PR DESCRIPTION
Fixes PCIOS-936

Points the Discover page at the v4 content endpoints. `DiscoverType.path` now requests `content_v4.json`, `content_v4_search.json`, `content_v4_logged_in.json`, and `content_v4_logged_out.json` instead of their v3 counterparts. The `content_v2.json` fallback used when the `recommendations` feature flag is off is unchanged.

## To test

1. Enable the `recommendations` feature flag.
2. Open the Discover tab and confirm the page loads with all sections rendering correctly.
3. Verify via Charles/Proxyman that the request goes to `https://static.pocketcasts.com/discover/ios/content_v4.json`.
4. Open Search and confirm the search Discover content loads (`content_v4_search.json`).
5. Sign out and back in, confirming the signed-out and signed-in variants load (`content_v4_logged_out.json` / `content_v4_logged_in.json`).

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
