### PR TITLE
Add the What's New catalog models, fetching, and caching

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
@@ -38,6 +38,10 @@ public enum ServerConstants {
             production() ? "https://lists.pocketcasts.com/" : "https://lists.pocketcasts.net/"
         }
 
+        public static func whatsNew() -> String {
+            production() ? "https://static.pocketcasts.com/whats-new/v1/ios/" : "https://static.pocketcasts.net/whats-new/v1/ios/"
+        }
+
         public static var search: String {
             production() ? "https://search.pocketcasts.com/" : "https://search.pocketcasts.net/"
         }

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewBlock.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewBlock.swift
@@ -77,6 +77,24 @@ public struct WhatsNewVideo: Decodable, Hashable {
     public let posterUrl: URL?
     public let alt: String?
     public let captionsUrl: URL?
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        _sources = try container.decode(LossyDecodedArray<Source>.self, forKey: .sources)
+        posterUrl = try container.decodeIfPresent(URL.self, forKey: .posterUrl)
+        alt = try container.decodeIfPresent(String.self, forKey: .alt)
+        captionsUrl = try container.decodeIfPresent(URL.self, forKey: .captionsUrl)
+        guard !sources.isEmpty else {
+            throw DecodingError.dataCorruptedError(forKey: .sources, in: container, debugDescription: "A video with no playable sources")
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sources
+        case posterUrl
+        case alt
+        case captionsUrl
+    }
 }
 
 public struct WhatsNewAction: Decodable, Hashable {

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewBlock.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewBlock.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// A single piece of content on a What's New page.
+///
+/// A block the app doesn't know about, such as `poll`, fails to decode and is dropped by the page's
+/// `LossyDecodedArray`, so the rest of the page still renders.
+public enum WhatsNewBlock: Decodable, Hashable {
+    case heading(WhatsNewHeading)
+    case paragraph(WhatsNewParagraph)
+    case image(WhatsNewImage)
+    case video(WhatsNewVideo)
+    case action(WhatsNewAction)
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(BlockType.self, forKey: .type) {
+        case .heading:
+            self = .heading(try WhatsNewHeading(from: decoder))
+        case .paragraph:
+            self = .paragraph(try WhatsNewParagraph(from: decoder))
+        case .image:
+            self = .image(try WhatsNewImage(from: decoder))
+        case .video:
+            self = .video(try WhatsNewVideo(from: decoder))
+        case .action:
+            self = .action(try WhatsNewAction(from: decoder))
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+    }
+
+    private enum BlockType: String, Decodable {
+        case heading
+        case paragraph
+        case image
+        case video
+        case action
+    }
+}
+
+public struct WhatsNewHeading: Decodable, Hashable {
+    public let level: Int
+    public let text: String
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        level = try container.decodeIfPresent(Int.self, forKey: .level) ?? 2
+        text = try container.decode(String.self, forKey: .text)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case level
+        case text
+    }
+}
+
+public struct WhatsNewParagraph: Decodable, Hashable {
+    public let content: String
+}
+
+public struct WhatsNewImage: Decodable, Hashable {
+    public let url: URL
+    public let width: Int?
+    public let height: Int?
+    public let alt: String?
+}
+
+public struct WhatsNewVideo: Decodable, Hashable {
+    public struct Source: Decodable, Hashable {
+        public let url: URL
+        public let mimeType: String?
+    }
+
+    @LossyDecodedArray public var sources: [Source]
+    public let posterUrl: URL?
+    public let alt: String?
+    public let captionsUrl: URL?
+}
+
+public struct WhatsNewAction: Decodable, Hashable {
+    public enum Style: String, Decodable, Hashable {
+        case primary
+        case secondary
+    }
+
+    public let label: String
+    public let url: URL
+    public let style: Style
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        label = try container.decode(String.self, forKey: .label)
+        url = try container.decode(URL.self, forKey: .url)
+        style = (try? container.decode(Style.self, forKey: .style)) ?? .primary
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case label
+        case url
+        case style
+    }
+}

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// The What's New feed published to the CDN for a single platform and locale.
+public struct WhatsNewCatalog: Decodable, Hashable {
+    public let schemaVersion: Int
+    public let generatedAt: Date?
+    public let platform: String?
+    public let locale: String?
+    @LossyDecodedArray public var messages: [WhatsNewMessage]
+
+    static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}
+
+/// A single item in the What's New feed.
+///
+/// A message with a `type` the app doesn't know about fails to decode and is dropped by the
+/// catalog's `LossyDecodedArray`, so the schema can gain new types without an iOS release.
+public struct WhatsNewMessage: Decodable, Hashable, Identifiable {
+    public let id: String
+    public let type: WhatsNewMessageType
+    public let publishedAt: Date
+    public let expiresAt: Date?
+    public let targeting: WhatsNewTargeting
+    public let summary: WhatsNewSummary
+    public let content: WhatsNewContent
+}
+
+public enum WhatsNewMessageType: String, Decodable, Hashable {
+    case newFeature = "new_feature"
+    case tip
+    case announcement
+    case knownIssue = "known_issue"
+    case research
+}
+
+/// The rules a client applies before a message can be shown.
+public struct WhatsNewTargeting: Decodable, Hashable {
+    @LossyDecodedArray public var audiences: [WhatsNewAudience]
+    public let minimumAppVersion: String?
+}
+
+public enum WhatsNewAudience: String, Decodable, Hashable {
+    case free
+    case plus
+    case patron
+}
+
+/// How a message is presented in the feed list.
+public struct WhatsNewSummary: Decodable, Hashable {
+    public let title: String
+    public let label: String?
+    public let imageUrl: URL?
+}
+
+/// How a message is presented once it's opened.
+public struct WhatsNewContent: Decodable, Hashable {
+    public let title: String?
+    @LossyDecodedArray public var pages: [WhatsNewPage]
+}
+
+public struct WhatsNewPage: Decodable, Hashable {
+    @LossyDecodedArray public var blocks: [WhatsNewBlock]
+}

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog.swift
@@ -96,11 +96,42 @@ public struct WhatsNewSummary: Decodable, Hashable {
 }
 
 /// How a message is presented once it's opened.
+///
+/// Content the app has nothing to render fails to decode, which drops the message it belongs to
+/// rather than showing a feed item that opens onto an empty pager.
 public struct WhatsNewContent: Decodable, Hashable {
     public let title: String?
     @LossyDecodedArray public var pages: [WhatsNewPage]
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        _pages = try container.decode(LossyDecodedArray<WhatsNewPage>.self, forKey: .pages)
+        guard !pages.isEmpty else {
+            throw DecodingError.dataCorruptedError(forKey: .pages, in: container, debugDescription: "Content with no renderable pages")
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case title
+        case pages
+    }
 }
 
+/// A single page of a message, dropped by the content's `LossyDecodedArray` when none of its blocks
+/// are ones the app knows how to render.
 public struct WhatsNewPage: Decodable, Hashable {
     @LossyDecodedArray public var blocks: [WhatsNewBlock]
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        _blocks = try container.decode(LossyDecodedArray<WhatsNewBlock>.self, forKey: .blocks)
+        guard !blocks.isEmpty else {
+            throw DecodingError.dataCorruptedError(forKey: .blocks, in: container, debugDescription: "A page with no renderable blocks")
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case blocks
+    }
 }

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog.swift
@@ -39,8 +39,31 @@ public enum WhatsNewMessageType: String, Decodable, Hashable {
 
 /// The rules a client applies before a message can be shown.
 public struct WhatsNewTargeting: Decodable, Hashable {
-    @LossyDecodedArray public var audiences: [WhatsNewAudience]
+    /// The audiences as published, including any this version of the app doesn't understand.
+    @LossyDecodedArray public var rawAudiences: [String]
     public let minimumAppVersion: String?
+
+    /// The audiences this version of the app understands.
+    ///
+    /// Fewer of these than there are `rawAudiences` means the message is aimed at a tier this
+    /// version can't evaluate, which isn't the same as a message that isn't aimed at anyone.
+    public var audiences: [WhatsNewAudience] {
+        rawAudiences.compactMap(WhatsNewAudience.init(rawValue:))
+    }
+
+    /// Whether a user in `audience` is targeted by the message.
+    ///
+    /// A message with no audiences is for everyone. A message aimed only at audiences this version
+    /// doesn't understand is for nobody, so an unknown tier hides the message rather than showing
+    /// it to every user.
+    public func targets(_ audience: WhatsNewAudience) -> Bool {
+        rawAudiences.isEmpty || rawAudiences.contains(audience.rawValue)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case rawAudiences = "audiences"
+        case minimumAppVersion
+    }
 }
 
 public enum WhatsNewAudience: String, Decodable, Hashable {

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog.swift
@@ -10,9 +10,25 @@ public struct WhatsNewCatalog: Decodable, Hashable {
 
     static let decoder: JSONDecoder = {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let string = try container.decode(String.self)
+            guard let date = WhatsNewCatalog.date(from: string) else {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Not an ISO 8601 date: \(string)")
+            }
+            return date
+        }
         return decoder
     }()
+
+    /// Parses an ISO 8601 timestamp with or without fractional seconds.
+    private static func date(from string: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: string) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: string)
+    }
 }
 
 /// A single item in the What's New feed.

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalogCache.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalogCache.swift
@@ -1,0 +1,32 @@
+import Foundation
+import PocketCastsUtils
+
+/// Keeps the last successfully fetched What's New catalog on disk so the feed works offline.
+public struct WhatsNewCatalogCache {
+    private let directory: URL
+
+    public init(directory: URL = WhatsNewCatalogCache.defaultDirectory) {
+        self.directory = directory
+    }
+
+    public static var defaultDirectory: URL {
+        URL.cachesDirectory.appending(path: "whats-new", directoryHint: .isDirectory)
+    }
+
+    public func data(forLocale locale: String) -> Data? {
+        try? Data(contentsOf: fileURL(forLocale: locale))
+    }
+
+    public func save(_ data: Data, forLocale locale: String) {
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try data.write(to: fileURL(forLocale: locale), options: .atomic)
+        } catch {
+            FileLog.shared.addMessage("What's New: failed to cache the catalog: \(error.localizedDescription)")
+        }
+    }
+
+    private func fileURL(forLocale locale: String) -> URL {
+        directory.appending(path: "catalog-\(locale).json")
+    }
+}

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalogTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalogTask.swift
@@ -27,12 +27,13 @@ public struct WhatsNewCatalogTask {
     /// The catalog for the current locale, refreshed from the CDN.
     ///
     /// Falls back to the cached catalog when the request fails or returns something that can't be
-    /// decoded, and only rethrows when there's nothing cached to fall back to.
+    /// decoded, and only rethrows when the refresh was cancelled or there's nothing cached to fall
+    /// back to.
     public func catalog() async throws -> WhatsNewCatalog {
         do {
             return try await refresh()
         } catch {
-            guard let cached = cachedCatalog() else { throw error }
+            guard !error.isCancellation, let cached = cachedCatalog() else { throw error }
             FileLog.shared.addMessage("What's New: catalog request failed: \(error.localizedDescription). Returning the cached catalog")
             return cached
         }
@@ -60,5 +61,11 @@ public struct WhatsNewCatalogTask {
         let catalog = try WhatsNewCatalog.decoder.decode(WhatsNewCatalog.self, from: data)
         cache.save(data, forLocale: locale)
         return catalog
+    }
+}
+
+private extension Error {
+    var isCancellation: Bool {
+        self is CancellationError || (self as? URLError)?.code == .cancelled
     }
 }

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalogTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalogTask.swift
@@ -19,9 +19,12 @@ public struct WhatsNewCatalogTask {
         self.locale = locale
     }
 
+    /// The language the catalog falls back to when the CDN doesn't publish the current one.
+    public static let fallbackLocale = "en"
+
     /// The language the catalog is requested for, such as `en`.
     public static var currentLocale: String {
-        Locale.current.language.languageCode?.identifier ?? "en"
+        Locale.current.language.languageCode?.identifier ?? fallbackLocale
     }
 
     /// The catalog for the current locale, refreshed from the CDN.
@@ -46,7 +49,25 @@ public struct WhatsNewCatalogTask {
     }
 
     /// Fetches the catalog from the CDN, replacing the cached copy once it decodes.
+    ///
+    /// Requests the current language and falls back to `en` when the CDN doesn't publish it, so a
+    /// device set to a language the feed hasn't been translated into still sees the messages.
     public func refresh() async throws -> WhatsNewCatalog {
+        let data: Data
+        do {
+            data = try await fetchData(forLocale: locale)
+        } catch WhatsNewCatalogError.requestFailed(let statusCode)
+                    where statusCode == ServerConstants.HttpConstants.notFound && locale != Self.fallbackLocale {
+            FileLog.shared.addMessage("What's New: no catalog published for \(locale). Falling back to \(Self.fallbackLocale)")
+            data = try await fetchData(forLocale: Self.fallbackLocale)
+        }
+
+        let catalog = try WhatsNewCatalog.decoder.decode(WhatsNewCatalog.self, from: data)
+        cache.save(data, forLocale: locale)
+        return catalog
+    }
+
+    private func fetchData(forLocale locale: String) async throws -> Data {
         let url = try URL(throwing: ServerConstants.Urls.whatsNew() + "\(locale).json")
         var request = URLRequest(url: url, cachePolicy: .reloadRevalidatingCacheData, timeoutInterval: 30.seconds)
         request.addLocalizationHeaders()
@@ -57,10 +78,7 @@ public struct WhatsNewCatalogTask {
         guard statusCode == ServerConstants.HttpConstants.ok else {
             throw WhatsNewCatalogError.requestFailed(statusCode: statusCode)
         }
-
-        let catalog = try WhatsNewCatalog.decoder.decode(WhatsNewCatalog.self, from: data)
-        cache.save(data, forLocale: locale)
-        return catalog
+        return data
     }
 }
 

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalogTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalogTask.swift
@@ -1,0 +1,64 @@
+import Foundation
+import PocketCastsUtils
+
+/// Fetches the What's New catalog published to the CDN, caching the last good copy on disk.
+public struct WhatsNewCatalogTask {
+    public enum WhatsNewCatalogError: Error {
+        case requestFailed(statusCode: Int)
+    }
+
+    private let session: URLSession
+    private let cache: WhatsNewCatalogCache
+    private let locale: String
+
+    public init(session: URLSession = .shared,
+                cache: WhatsNewCatalogCache = WhatsNewCatalogCache(),
+                locale: String = WhatsNewCatalogTask.currentLocale) {
+        self.session = session
+        self.cache = cache
+        self.locale = locale
+    }
+
+    /// The language the catalog is requested for, such as `en`.
+    public static var currentLocale: String {
+        Locale.current.language.languageCode?.identifier ?? "en"
+    }
+
+    /// The catalog for the current locale, refreshed from the CDN.
+    ///
+    /// Falls back to the cached catalog when the request fails or returns something that can't be
+    /// decoded, and only rethrows when there's nothing cached to fall back to.
+    public func catalog() async throws -> WhatsNewCatalog {
+        do {
+            return try await refresh()
+        } catch {
+            guard let cached = cachedCatalog() else { throw error }
+            FileLog.shared.addMessage("What's New: catalog request failed: \(error.localizedDescription). Returning the cached catalog")
+            return cached
+        }
+    }
+
+    /// The last catalog that was fetched successfully, read back from disk.
+    public func cachedCatalog() -> WhatsNewCatalog? {
+        guard let data = cache.data(forLocale: locale) else { return nil }
+        return try? WhatsNewCatalog.decoder.decode(WhatsNewCatalog.self, from: data)
+    }
+
+    /// Fetches the catalog from the CDN, replacing the cached copy once it decodes.
+    public func refresh() async throws -> WhatsNewCatalog {
+        let url = try URL(throwing: ServerConstants.Urls.whatsNew() + "\(locale).json")
+        var request = URLRequest(url: url, cachePolicy: .reloadRevalidatingCacheData, timeoutInterval: 30.seconds)
+        request.addLocalizationHeaders()
+
+        let (data, response) = try await session.data(for: request)
+
+        let statusCode = response.extractStatusCode()
+        guard statusCode == ServerConstants.HttpConstants.ok else {
+            throw WhatsNewCatalogError.requestFailed(statusCode: statusCode)
+        }
+
+        let catalog = try WhatsNewCatalog.decoder.decode(WhatsNewCatalog.self, from: data)
+        cache.save(data, forLocale: locale)
+        return catalog
+    }
+}

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewCatalogTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewCatalogTests.swift
@@ -267,6 +267,26 @@ final class WhatsNewCatalogTests: XCTestCase {
         XCTAssertEqual(cached.messages.map(\.id), fetched.messages.map(\.id))
     }
 
+    func testRefreshFallsBackToEnglishWhenTheLocaleIsNotPublished() async throws {
+        let task = WhatsNewCatalogTask(session: stubbedSession(), cache: temporaryCache(), locale: "pt")
+
+        var requestedPaths: [String] = []
+        StubURLProtocol.requestHandler = { [json] request in
+            let url = request.url!
+            requestedPaths.append(url.lastPathComponent)
+            guard url.lastPathComponent == "en.json" else {
+                return (HTTPURLResponse(url: url, statusCode: 404, httpVersion: nil, headerFields: nil)!, Data())
+            }
+            return (HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data(json.utf8))
+        }
+
+        let catalog = try await task.refresh()
+
+        XCTAssertEqual(requestedPaths, ["pt.json", "en.json"])
+        XCTAssertEqual(catalog.messages.count, 2)
+        XCTAssertEqual(task.cachedCatalog()?.messages.count, 2, "The fallback catalog is cached for the requested locale")
+    }
+
     func testCatalogRethrowsCancellationRatherThanReturningTheCachedCopy() async throws {
         let task = WhatsNewCatalogTask(session: stubbedSession(), cache: temporaryCache(), locale: "en")
 

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewCatalogTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewCatalogTests.swift
@@ -140,7 +140,26 @@ final class WhatsNewCatalogTests: XCTestCase {
         let blocks = try XCTUnwrap(message.content.pages.first?.blocks)
 
         XCTAssertEqual(blocks.count, 2, "The poll block is dropped, the paragraphs around it are kept")
-        XCTAssertEqual(message.targeting.audiences, [.free], "The unsupported audience is dropped")
+        XCTAssertEqual(message.targeting.rawAudiences, ["free", "future_audience"], "The unsupported audience is kept as published")
+        XCTAssertEqual(message.targeting.audiences, [.free], "Only the audiences this version understands are mapped")
+    }
+
+    func testAMessageAimedOnlyAtAnUnknownAudienceTargetsNobody() throws {
+        let targeting = try decodedTargeting(#"{ "audiences": ["future_tier"] }"#)
+
+        XCTAssertTrue(targeting.audiences.isEmpty)
+        XCTAssertFalse(targeting.targets(.free), "An audience this version can't evaluate hides the message")
+        XCTAssertFalse(targeting.targets(.plus))
+        XCTAssertFalse(targeting.targets(.patron))
+    }
+
+    func testAMessageWithNoAudiencesTargetsEveryone() throws {
+        let targeting = try decodedTargeting("{}")
+
+        XCTAssertTrue(targeting.rawAudiences.isEmpty)
+        XCTAssertTrue(targeting.targets(.free))
+        XCTAssertTrue(targeting.targets(.plus))
+        XCTAssertTrue(targeting.targets(.patron))
     }
 
     func testCatalogFallsBackToTheCachedCopyWhenTheRequestFails() async throws {
@@ -169,6 +188,10 @@ final class WhatsNewCatalogTests: XCTestCase {
         } catch {
             XCTAssertEqual((error as? URLError)?.code, .notConnectedToInternet)
         }
+    }
+
+    private func decodedTargeting(_ json: String) throws -> WhatsNewTargeting {
+        try WhatsNewCatalog.decoder.decode(WhatsNewTargeting.self, from: Data(json.utf8))
     }
 
     private func decodedCatalog() throws -> WhatsNewCatalog {

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewCatalogTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewCatalogTests.swift
@@ -1,0 +1,221 @@
+import Foundation
+@testable import PocketCastsServer
+import XCTest
+
+final class WhatsNewCatalogTests: XCTestCase {
+    /// A catalog shaped like the published contract, with a message type, an audience, and a block
+    /// that this version of the app doesn't know about.
+    private let json = """
+    {
+      "schemaVersion": 1,
+      "generatedAt": "2026-08-17T10:30:00Z",
+      "platform": "ios",
+      "locale": "en",
+      "messages": [
+        {
+          "id": "01K2Y08DAWG9N7XJZX5QTH9Z0K",
+          "type": "new_feature",
+          "publishedAt": "2026-08-17T08:00:00Z",
+          "expiresAt": "2026-09-17T08:00:00Z",
+          "targeting": { "audiences": ["free", "plus", "patron"], "minimumAppVersion": null },
+          "summary": {
+            "title": "Introducing episode transcripts",
+            "label": "New Feature",
+            "imageUrl": "https://static.pocketcasts.com/whats-new/media/transcripts-card.webp"
+          },
+          "content": {
+            "title": "Introducing episode transcripts",
+            "pages": [
+              {
+                "blocks": [
+                  { "type": "heading", "level": 2, "text": "Read along while you listen" },
+                  { "type": "paragraph", "content": "Search a transcript and follow the conversation." },
+                  {
+                    "type": "image",
+                    "url": "https://static.pocketcasts.com/whats-new/media/transcripts-detail.webp",
+                    "width": 1200,
+                    "height": 750,
+                    "alt": "Episode transcript open beside the player"
+                  }
+                ]
+              },
+              {
+                "blocks": [
+                  { "type": "action", "label": "Try transcripts", "url": "pocketcasts://podcasts", "style": "primary" }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "01K2Y2CFD0VAWA4N74D3N6JTVK",
+          "type": "research",
+          "publishedAt": "2026-08-12T09:00:00Z",
+          "targeting": { "audiences": ["free", "future_audience"] },
+          "summary": { "title": "Help shape the player" },
+          "content": {
+            "pages": [
+              {
+                "blocks": [
+                  { "type": "paragraph", "content": "Which improvement would make the biggest difference?" },
+                  { "type": "poll", "pollId": "01K2Y2S65F22TQZQJVNAEXQKHT", "question": "What next?", "options": [] },
+                  { "type": "paragraph", "content": "The survey takes about two minutes." }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "01K2Y1JQ4T7Z7T5RY8G0QPA3NX",
+          "type": "future_type",
+          "publishedAt": "2026-08-14T08:00:00Z",
+          "targeting": { "audiences": ["plus"] },
+          "summary": { "title": "Something new" },
+          "content": { "pages": [] }
+        }
+      ]
+    }
+    """
+
+    override func tearDown() {
+        StubURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func testDecodesMessagesAndDropsUnknownTypes() throws {
+        let catalog = try decodedCatalog()
+
+        XCTAssertEqual(catalog.schemaVersion, 1)
+        XCTAssertEqual(catalog.locale, "en")
+        XCTAssertEqual(catalog.messages.map(\.id),
+                       ["01K2Y08DAWG9N7XJZX5QTH9Z0K", "01K2Y2CFD0VAWA4N74D3N6JTVK"],
+                       "The unsupported message type is dropped rather than failing the whole feed")
+
+        let message = try XCTUnwrap(catalog.messages.first)
+        XCTAssertEqual(message.type, .newFeature)
+        XCTAssertEqual(message.summary.title, "Introducing episode transcripts")
+        XCTAssertEqual(message.summary.label, "New Feature")
+        XCTAssertEqual(message.publishedAt, ISO8601DateFormatter().date(from: "2026-08-17T08:00:00Z"))
+        XCTAssertEqual(message.expiresAt, ISO8601DateFormatter().date(from: "2026-09-17T08:00:00Z"))
+        XCTAssertEqual(message.targeting.audiences, [.free, .plus, .patron])
+        XCTAssertNil(message.targeting.minimumAppVersion)
+        XCTAssertEqual(message.content.pages.count, 2)
+    }
+
+    func testDecodesSupportedBlocks() throws {
+        let pages = try XCTUnwrap(decodedCatalog().messages.first?.content.pages)
+
+        guard case .heading(let heading) = pages[0].blocks[0] else {
+            XCTFail("Expected a heading block, got \(pages[0].blocks[0])")
+            return
+        }
+        XCTAssertEqual(heading.level, 2)
+        XCTAssertEqual(heading.text, "Read along while you listen")
+
+        guard case .paragraph(let paragraph) = pages[0].blocks[1] else {
+            XCTFail("Expected a paragraph block, got \(pages[0].blocks[1])")
+            return
+        }
+        XCTAssertEqual(paragraph.content, "Search a transcript and follow the conversation.")
+
+        guard case .image(let image) = pages[0].blocks[2] else {
+            XCTFail("Expected an image block, got \(pages[0].blocks[2])")
+            return
+        }
+        XCTAssertEqual(image.width, 1200)
+        XCTAssertEqual(image.height, 750)
+        XCTAssertEqual(image.alt, "Episode transcript open beside the player")
+
+        guard case .action(let action) = pages[1].blocks[0] else {
+            XCTFail("Expected an action block, got \(pages[1].blocks[0])")
+            return
+        }
+        XCTAssertEqual(action.label, "Try transcripts")
+        XCTAssertEqual(action.url, URL(string: "pocketcasts://podcasts"))
+        XCTAssertEqual(action.style, .primary)
+    }
+
+    func testDropsUnknownBlocksAndAudiencesWithoutLosingTheirNeighbours() throws {
+        let message = try XCTUnwrap(decodedCatalog().messages.last)
+        let blocks = try XCTUnwrap(message.content.pages.first?.blocks)
+
+        XCTAssertEqual(blocks.count, 2, "The poll block is dropped, the paragraphs around it are kept")
+        XCTAssertEqual(message.targeting.audiences, [.free], "The unsupported audience is dropped")
+    }
+
+    func testCatalogFallsBackToTheCachedCopyWhenTheRequestFails() async throws {
+        let task = WhatsNewCatalogTask(session: stubbedSession(), cache: temporaryCache(), locale: "en")
+
+        StubURLProtocol.requestHandler = { [json] request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(json.utf8))
+        }
+        let fetched = try await task.catalog()
+        XCTAssertEqual(fetched.messages.count, 2)
+
+        StubURLProtocol.requestHandler = { _ in throw URLError(.notConnectedToInternet) }
+        let cached = try await task.catalog()
+        XCTAssertEqual(cached.messages.map(\.id), fetched.messages.map(\.id))
+    }
+
+    func testCatalogThrowsWhenTheRequestFailsAndNothingIsCached() async {
+        let task = WhatsNewCatalogTask(session: stubbedSession(), cache: temporaryCache(), locale: "en")
+
+        StubURLProtocol.requestHandler = { _ in throw URLError(.notConnectedToInternet) }
+
+        do {
+            _ = try await task.catalog()
+            XCTFail("Expected the request to fail")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .notConnectedToInternet)
+        }
+    }
+
+    private func decodedCatalog() throws -> WhatsNewCatalog {
+        try WhatsNewCatalog.decoder.decode(WhatsNewCatalog.self, from: Data(json.utf8))
+    }
+
+    private func stubbedSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private func temporaryCache() -> WhatsNewCatalogCache {
+        let directory = URL.temporaryDirectory.appending(path: "whats-new-tests-\(UUID().uuidString)", directoryHint: .isDirectory)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return WhatsNewCatalogCache(directory: directory)
+    }
+}
+
+private final class StubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let requestHandler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (response, data) = try requestHandler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewCatalogTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewCatalogTests.swift
@@ -135,6 +135,33 @@ final class WhatsNewCatalogTests: XCTestCase {
         XCTAssertEqual(action.style, .primary)
     }
 
+    func testDecodesTimestampsWithFractionalSeconds() throws {
+        let json = """
+        {
+          "schemaVersion": 1,
+          "generatedAt": "2026-08-17T10:30:00.000Z",
+          "messages": [
+            {
+              "id": "01K2Y08DAWG9N7XJZX5QTH9Z0K",
+              "type": "tip",
+              "publishedAt": "2026-08-17T08:00:00.123Z",
+              "targeting": {},
+              "summary": { "title": "Sleep timer shortcuts" },
+              "content": { "pages": [{ "blocks": [{ "type": "paragraph", "content": "Hold the sleep timer button." }] }] }
+            }
+          ]
+        }
+        """
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let catalog = try WhatsNewCatalog.decoder.decode(WhatsNewCatalog.self, from: Data(json.utf8))
+
+        XCTAssertEqual(catalog.generatedAt, formatter.date(from: "2026-08-17T10:30:00.000Z"))
+        XCTAssertEqual(catalog.messages.count, 1, "A timestamp with fractional seconds doesn't drop the message")
+        XCTAssertEqual(catalog.messages.first?.publishedAt, formatter.date(from: "2026-08-17T08:00:00.123Z"))
+    }
+
     func testDropsUnknownBlocksAndAudiencesWithoutLosingTheirNeighbours() throws {
         let message = try XCTUnwrap(decodedCatalog().messages.last)
         let blocks = try XCTUnwrap(message.content.pages.first?.blocks)

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewCatalogTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewCatalogTests.swift
@@ -135,6 +135,69 @@ final class WhatsNewCatalogTests: XCTestCase {
         XCTAssertEqual(action.style, .primary)
     }
 
+    func testDropsPagesAndMessagesWithNothingToRender() throws {
+        let json = """
+        {
+          "schemaVersion": 1,
+          "messages": [
+            {
+              "id": "01K2Y2CFD0VAWA4N74D3N6JTVK",
+              "type": "tip",
+              "publishedAt": "2026-08-17T08:00:00Z",
+              "targeting": {},
+              "summary": { "title": "One page of its own" },
+              "content": {
+                "pages": [
+                  { "blocks": [{ "type": "poll", "pollId": "01K2Y2S65F22TQZQJVNAEXQKHT" }] },
+                  { "blocks": [{ "type": "paragraph", "content": "This page still renders." }] }
+                ]
+              }
+            },
+            {
+              "id": "01K2Y1JQ4T7Z7T5RY8G0QPA3NX",
+              "type": "tip",
+              "publishedAt": "2026-08-17T08:00:00Z",
+              "targeting": {},
+              "summary": { "title": "Nothing to render" },
+              "content": { "pages": [{ "blocks": [{ "type": "poll", "pollId": "01K2Y2S65F22TQZQJVNAEXQKHT" }] }] }
+            }
+          ]
+        }
+        """
+
+        let catalog = try WhatsNewCatalog.decoder.decode(WhatsNewCatalog.self, from: Data(json.utf8))
+
+        XCTAssertEqual(catalog.messages.map(\.id), ["01K2Y2CFD0VAWA4N74D3N6JTVK"],
+                       "A message whose pages have nothing renderable is dropped rather than opening onto an empty pager")
+        XCTAssertEqual(catalog.messages.first?.content.pages.count, 1,
+                       "The page of unknown blocks is dropped, the page beside it is kept")
+    }
+
+    func testDropsVideoBlocksWithNoPlayableSources() throws {
+        let json = """
+        {
+          "blocks": [
+            { "type": "video", "posterUrl": "https://static.pocketcasts.com/whats-new/media/transcripts-poster.webp" },
+            {
+              "type": "video",
+              "sources": [{ "url": "https://static.pocketcasts.com/whats-new/media/transcripts.mp4", "mimeType": "video/mp4" }],
+              "alt": "Scrolling through a transcript"
+            }
+          ]
+        }
+        """
+
+        let page = try WhatsNewCatalog.decoder.decode(WhatsNewPage.self, from: Data(json.utf8))
+
+        XCTAssertEqual(page.blocks.count, 1, "The video with no playable sources is dropped")
+        guard case .video(let video) = page.blocks[0] else {
+            XCTFail("Expected a video block, got \(page.blocks[0])")
+            return
+        }
+        XCTAssertEqual(video.sources.map(\.url), [URL(string: "https://static.pocketcasts.com/whats-new/media/transcripts.mp4")])
+        XCTAssertEqual(video.alt, "Scrolling through a transcript")
+    }
+
     func testDecodesTimestampsWithFractionalSeconds() throws {
         let json = """
         {

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewCatalogTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewCatalogTests.swift
@@ -267,6 +267,25 @@ final class WhatsNewCatalogTests: XCTestCase {
         XCTAssertEqual(cached.messages.map(\.id), fetched.messages.map(\.id))
     }
 
+    func testCatalogRethrowsCancellationRatherThanReturningTheCachedCopy() async throws {
+        let task = WhatsNewCatalogTask(session: stubbedSession(), cache: temporaryCache(), locale: "en")
+
+        StubURLProtocol.requestHandler = { [json] request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(json.utf8))
+        }
+        _ = try await task.catalog()
+
+        StubURLProtocol.requestHandler = { _ in throw URLError(.cancelled) }
+
+        do {
+            _ = try await task.catalog()
+            XCTFail("Expected the cancelled request to propagate")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .cancelled)
+        }
+    }
+
     func testCatalogThrowsWhenTheRequestFailsAndNothingIsCached() async {
         let task = WhatsNewCatalogTask(session: stubbedSession(), cache: temporaryCache(), locale: "en")
 


### PR DESCRIPTION
| 📘 Part of: What's New Messages |
|:---:|

Fixes PCIOS-923

Adds the What's New content layer to `PocketCastsServer`: `Codable` models for the CDN catalog, a task that fetches it, and a disk cache that keeps the last good copy.

- `WhatsNewCatalog` and friends model the published contract — messages with targeting, a feed summary, and one or more content pages of `heading` / `paragraph` / `image` / `video` / `action` blocks.
- Unknown message types, audiences, and blocks are dropped by the existing `LossyDecodedArray` instead of failing the payload, so the schema can grow without an iOS release. `poll` is deliberately unmodelled — its submission contract is still undecided, so it decodes as an ignorable block for now.
- `WhatsNewCatalogTask.catalog()` fetches `static.pocketcasts.com/whats-new/v1/ios/{language}.json` and falls back to `WhatsNewCatalogCache` when the request fails, so the feed still works offline. It only rethrows when there's nothing cached.

Two things worth flagging:

- The `video` block's exact fields aren't pinned down in the plan (it only says "sources, poster image, alternative text, and captions"), so the shape here is a best guess. Getting it wrong is cheap — the block drops and the rest of the page still renders — and it can be corrected in PCIOS-928 when video is implemented.
- Locale fallback is still an open question in the plan, so this requests the current language and nothing else. If the CDN only publishes a subset of locales, we'll want to fall back to `en` on a 404.

No caller yet, so nothing here is behind the `whatsNewFeed` flag — the flag gates the Profile entry point in PCIOS-925.

## To test

There's no UI yet, so this is covered by unit tests:

1. `cd Modules`
2. `xcodebuild test -scheme Modules-Package -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -only-testing:PocketCastsServerTests/WhatsNewCatalogTests`
3. All 5 tests pass — decoding the contract example, each supported block, dropping unknown types/audiences/blocks, the offline cache fallback, and the error when nothing is cached.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
