### PR TITLE
Fix ambiguous Task.init build error on Xcode 27

### DIFF
--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -986,7 +986,7 @@ private extension MainTabBarController {
             .compactMap { event in
                 bookmarkManager.bookmark(for: event.uuid).map { ($0, event.source) }
             }
-            .sink { bookmark, source in
+            .sink { (bookmark: Bookmark, source: BookmarkAnalyticsSource) in
                 Task {
                     await bookmarkManager.enrich(bookmark, source: source)
                 }


### PR DESCRIPTION
Xcode 27 fails to build `MainTabBarController.swift`:

```
podcasts/Main/MainTabBarController.swift:990:17: error: ambiguous use of 'init(name:priority:operation:)'
```

`onBookmarkCreated` is `compactMap`-ed into a tuple, and the `sink` closure splats that tuple into two un-annotated parameters. Swift 6.4 no longer resolves those parameter types before it ranks the `Task` initializers, so the throwing and non-throwing overloads both stay viable and the call goes ambiguous. Spelling out the two parameter types resolves them up front and the non-throwing overload wins again.

I probed the alternatives on Xcode 27 — pinning `Task<Void, Never>`, dropping the tuple from the pipeline, and re-binding the values with explicit types all work too; annotating the closure parameters is the smallest change and keeps the pipeline as it reads today. Annotating `compactMap`'s return type, adding `@MainActor` to the `Task`, and dropping the tuple splat in favour of `pair.0` / `pair.1` do *not* fix it.

Verified with a full build of `Pocket Casts Staging` on both Xcode 27.0 beta 6 (fails on trunk, succeeds with this change) and Xcode 26.5 (still succeeds).

## To test

1. Open the project in Xcode 27.
2. Build the `Pocket Casts Staging` scheme — it should compile.
3. Play an episode, background the app, and add a bookmark with the headphone button.
4. Reopen the app and confirm the bookmark got a generated title.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
