### PR TITLE
Match Figma for the networks grid

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		0C52E9EC2FFD8DAD00C2B9D1 /* TroubleshootingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C52E9EB2FFD8DAD00C2B9D1 /* TroubleshootingView.swift */; };
 		0C52E9EE2FFD8DB600C2B9D1 /* OrphanedEpisodesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C52E9ED2FFD8DB600C2B9D1 /* OrphanedEpisodesListView.swift */; };
 		0C7BFA882FAD2A8C00C1E5FF /* LiquidGlass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9984A1B5C2D00000003 /* LiquidGlass.swift */; };
+		0CAF5067304B019B00E6074E /* DiscoverNetworksGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAF5066304B019B00E6074E /* DiscoverNetworksGridView.swift */; };
 		0CB804A62FB50B31007D0402 /* PlayerZoomAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB804A52FB50B31007D0402 /* PlayerZoomAnimator.swift */; };
 		0CCC37A62FA3C30200BA79D1 /* SmartPlaylistRulesSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCC37A52FA3C30200BA79D1 /* SmartPlaylistRulesSectionView.swift */; };
 		0CF5B7BE2FB3B0E60023691C /* LiquidGlass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9984A1B5C2D00000003 /* LiquidGlass.swift */; };
@@ -1627,6 +1628,7 @@
 		0C52E9E92FFD8D9B00C2B9D1 /* TroubleshootingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TroubleshootingViewModel.swift; sourceTree = "<group>"; };
 		0C52E9EB2FFD8DAD00C2B9D1 /* TroubleshootingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TroubleshootingView.swift; sourceTree = "<group>"; };
 		0C52E9ED2FFD8DB600C2B9D1 /* OrphanedEpisodesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrphanedEpisodesListView.swift; sourceTree = "<group>"; };
+		0CAF5066304B019B00E6074E /* DiscoverNetworksGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverNetworksGridView.swift; sourceTree = "<group>"; };
 		0CB804A52FB50B31007D0402 /* PlayerZoomAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerZoomAnimator.swift; sourceTree = "<group>"; };
 		0CCC37A52FA3C30200BA79D1 /* SmartPlaylistRulesSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPlaylistRulesSectionView.swift; sourceTree = "<group>"; };
 		10097D272CC7DADA00E682A3 /* UpNext.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = UpNext.xcassets; sourceTree = "<group>"; };
@@ -4229,6 +4231,7 @@
 				FFA1000000000000000002AA /* DiscoverNetworksListModel.swift */,
 				FFA1000000000000000003AA /* DiscoverNetworksListViewController.swift */,
 				FFA1000000000000000004AA /* NetworkNavigator.swift */,
+				0CAF5066304B019B00E6074E /* DiscoverNetworksGridView.swift */,
 			);
 			name = Network;
 			sourceTree = "<group>";
@@ -7061,6 +7064,7 @@
 				8B317BA028906A8900A26A13 /* main.swift in Sources */,
 				BDC86830238251B0004C998F /* NowPlayingPlayerItemViewController+UpNextPan.swift in Sources */,
 				BD7BCF131F6A4F920006E008 /* SharingItemProvider.swift in Sources */,
+				0CAF5067304B019B00E6074E /* DiscoverNetworksGridView.swift in Sources */,
 				BDE7409A2060CE1B00FB22C7 /* EpisodeManager.swift in Sources */,
 				F54E721D2CA7359800CD5C86 /* DiscoverCellType.swift in Sources */,
 				F5A1D4022FBE10A100E1A001 /* UnknownDiscoverItemAlert.swift in Sources */,

--- a/podcasts/Discover Previews/DiscoverPreviewData.swift
+++ b/podcasts/Discover Previews/DiscoverPreviewData.swift
@@ -170,26 +170,42 @@ enum DiscoverPreviewData {
         ])
     }
 
-    private static let networkNames = [
-        "The New York Times", "The Economist", "SiriusXM", "NPR", "Goalhanger", "Wondery"
+    /// Networks the live `lists_list` carries, so previews show the logos and blurbs of real ones.
+    private static let networks: [(uuid: String, title: String, description: String, imageType: String, itemCount: Int)] = [
+        ("88094252-ec9a-4c96-9120-95413664d9de", "The New York Times", "The New York Times collection of podcasts", "png", 12),
+        ("979866dc-fcb6-400d-8586-9e5003ef33b8", "Relay", "The Relay collection of podcasts.", "png", 19),
+        ("71c61818-1a5b-4bc5-9bb4-605318342b0c", "Maximum Fun", "Artist-owned comedy & culture shows", "jpg", 41),
+        ("a3d4dc76-3d2d-4698-bf2d-b01897512ed6", "Crime House", "Uncovering the truth", "jpg", 8),
+        ("af1ded0b-bea1-4abc-ac0f-3881cb41b57d", "Podmasters", "Exciting character-driven podcasts", "jpg", 7),
+        ("e8d51650-df8a-4a5e-a157-1f7b636fac8d", "Higher Ground", "Widely acclaimed stories that move culture forward", "jpg", 9),
+        ("6dd34339-bc03-4539-abae-4e3ff5b9fe59", "The Sonar Podcast Network", "The funny & the fascinating.", "jpg", 9),
+        ("4562eca8-14fd-4661-97bb-362a728d7e9f", "Slumber Studios", "The perfect podcasts for bedtime.", "jpg", 5),
+        ("77734d74-bdce-4934-87b0-40c8e33e3962", "Pushkin Industries", "Good, Smart, Fun.", "jpg", 10),
+        ("084e3d50-159e-464a-9642-24e0be93af3d", "Multitude", "We contain worlds", "jpg", 8),
+        ("b9028838-a60e-474a-9fe3-69a22c321286", "TAPEDECK", "Independent podcasts with familiar voices.", "jpg", 10),
+        ("da7e9206-3777-4715-ae60-29de3418bb1e", "Broads and Books Productions", "Broads and Books Productions creates podcasts that make you laugh, think, rage, and all of the above.", "jpg", 4),
+        ("45453984-cba5-4613-9d7a-bb73dd7a9f6b", "RNZ", "The best podcasts from New Zealand", "jpg", 25),
+        ("872898e6-33d5-48a9-b824-15104c64f5bc", "Atypical Artists", "Stories for your ears and hearts.", "jpg", 12)
     ]
 
     /// The `lists_list` payload: a collection whose entries are podcast lists, one per network.
+    ///
+    /// Tops out at the number of networks the fixture holds, so every entry stays a distinct one.
     static func networkCollection(title: String, count: Int = 6) -> PodcastCollection {
         decode(PodcastCollection.self, from: [
             "list_id": "preview-networks",
             "title": title,
-            "lists": (0 ..< count).map { index in
+            "lists": networks.prefix(count).map { network in
                 [
-                    "uuid": "preview-network-\(index)",
-                    "title": networkNames[index % networkNames.count],
+                    "uuid": network.uuid,
+                    "title": network.title,
                     "type": NetworkListSummary.supportedType,
-                    "summary_style": "small_list",
-                    "expanded_style": "grid",
-                    "source": "https://lists.pocketcasts.com/preview-network-\(index).json",
-                    "collection_image": artworkURL(at: index),
-                    "item_count": 8 + index,
-                    "description": blurbs[index % blurbs.count]
+                    "summary_style": "collection",
+                    "expanded_style": "network_grid",
+                    "source": "https://lists.pocketcasts.com/\(network.uuid).json",
+                    "collection_image": "https://static.pocketcasts.com/share/images/\(network.uuid)-author.\(network.imageType)",
+                    "item_count": network.itemCount,
+                    "description": network.description
                 ]
             },
             "datetime": datetime

--- a/podcasts/DiscoverNetworksGridView.swift
+++ b/podcasts/DiscoverNetworksGridView.swift
@@ -73,12 +73,21 @@ class DiscoverNetworksGridViewController: ThemedHostingController<DiscoverNetwor
 #if DEBUG
 
 #Preview("Networks grid") {
+    networksGridPreview(theme: .light)
+}
+
+/// The app draws its own colours, so a dark grid takes a dark ``Theme``, not a dark appearance.
+#Preview("Networks grid, dark") {
+    networksGridPreview(theme: .dark)
+}
+
+private func networksGridPreview(theme: Theme.ThemeType) -> some View {
     NavigationStack {
         DiscoverNetworksGridView(
             networks: DiscoverPreviewData.networkCollection(title: "Networks", count: 12).lists,
             onSelect: { _ in }
         )
-        .setupDefaultEnvironment()
+        .setupDefaultEnvironment(theme: Theme(previewTheme: theme))
         .navigationTitle(Text("Networks"))
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/podcasts/DiscoverNetworksGridView.swift
+++ b/podcasts/DiscoverNetworksGridView.swift
@@ -74,7 +74,7 @@ class DiscoverNetworksGridViewController: ThemedHostingController<DiscoverNetwor
 
 #Preview("Networks grid") {
     DiscoverNetworksGridView(
-        networks: DiscoverPreviewData.networkCollection(title: "Networks").lists,
+        networks: DiscoverPreviewData.networkCollection(title: "Networks", count: 12).lists,
         onSelect: { _ in }
     )
     .setupDefaultEnvironment()

--- a/podcasts/DiscoverNetworksGridView.swift
+++ b/podcasts/DiscoverNetworksGridView.swift
@@ -73,21 +73,12 @@ class DiscoverNetworksGridViewController: ThemedHostingController<DiscoverNetwor
 #if DEBUG
 
 #Preview("Networks grid") {
-    networksGridPreview(theme: .light)
-}
-
-/// The app draws its own colours, so a dark grid takes a dark ``Theme``, not a dark appearance.
-#Preview("Networks grid, dark") {
-    networksGridPreview(theme: .dark)
-}
-
-private func networksGridPreview(theme: Theme.ThemeType) -> some View {
     NavigationStack {
         DiscoverNetworksGridView(
             networks: DiscoverPreviewData.networkCollection(title: "Networks", count: 12).lists,
             onSelect: { _ in }
         )
-        .setupDefaultEnvironment(theme: Theme(previewTheme: theme))
+        .previewFollowingAppearance()
         .navigationTitle(Text("Networks"))
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/podcasts/DiscoverNetworksGridView.swift
+++ b/podcasts/DiscoverNetworksGridView.swift
@@ -73,11 +73,15 @@ class DiscoverNetworksGridViewController: ThemedHostingController<DiscoverNetwor
 #if DEBUG
 
 #Preview("Networks grid") {
-    DiscoverNetworksGridView(
-        networks: DiscoverPreviewData.networkCollection(title: "Networks", count: 12).lists,
-        onSelect: { _ in }
-    )
-    .setupDefaultEnvironment()
+    NavigationStack {
+        DiscoverNetworksGridView(
+            networks: DiscoverPreviewData.networkCollection(title: "Networks", count: 12).lists,
+            onSelect: { _ in }
+        )
+        .setupDefaultEnvironment()
+        .navigationTitle(Text("Networks"))
+        .navigationBarTitleDisplayMode(.inline)
+    }
 }
 
 #endif

--- a/podcasts/DiscoverNetworksGridView.swift
+++ b/podcasts/DiscoverNetworksGridView.swift
@@ -1,0 +1,83 @@
+import PocketCastsServer
+import SwiftUI
+import UIKit
+
+/// The screen "Show all" opens from a `lists_list` row: every network in the list, in a grid.
+struct DiscoverNetworksGridView: View {
+
+    let networks: [NetworkListSummary]
+
+    let onSelect: (NetworkListSummary) -> Void
+
+    @EnvironmentObject var theme: Theme
+
+    private let inset: CGFloat = 24
+    private let minimumCardWidth: CGFloat = 150
+    private let columnSpacing: CGFloat = 18
+    private let rowSpacing: CGFloat = 24
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: minimumCardWidth), spacing: columnSpacing, alignment: .top)], spacing: rowSpacing) {
+                ForEach(networks, id: \.self) { network in
+                    Button {
+                        onSelect(network)
+                    } label: {
+                        DiscoverNetworkCard(network: network)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(inset)
+        }
+        .background(theme.primaryUi02)
+        .miniPlayerSafeAreaInset()
+    }
+}
+
+class DiscoverNetworksGridViewController: ThemedHostingController<DiscoverNetworksGridView> {
+
+    private let item: DiscoverItem
+
+    init(item: DiscoverItem, networks: [NetworkListSummary], onSelect: @escaping (NetworkListSummary) -> Void) {
+        self.item = item
+        super.init(rootView: DiscoverNetworksGridView(networks: networks, onSelect: onSelect), background: \.primaryUi02)
+
+        title = item.title?.localized.localizedCapitalized
+    }
+
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        if item.source != nil && item.isAuthenticated == false {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(named: "podcast-share"), style: .plain, target: self, action: #selector(handleShare))
+        }
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        AppTheme.defaultStatusBarStyle()
+    }
+
+    @objc private func handleShare() {
+        guard let source = item.source, let url = URL(string: source)?.deletingPathExtension() else { return }
+
+        Analytics.track(.discoverListShareTapped)
+        present(UIActivityViewController(activityItems: [url], applicationActivities: nil), animated: true)
+    }
+}
+
+#if DEBUG
+
+#Preview("Networks grid") {
+    DiscoverNetworksGridView(
+        networks: DiscoverPreviewData.networkCollection(title: "Networks").lists,
+        onSelect: { _ in }
+    )
+    .setupDefaultEnvironment()
+}
+
+#endif

--- a/podcasts/DiscoverNetworksListModel.swift
+++ b/podcasts/DiscoverNetworksListModel.swift
@@ -57,13 +57,9 @@ class DiscoverNetworksListModel: ObservableObject {
             Analytics.track(.discoverShowAllTapped, properties: ["list_id": item.inferredListId])
         }
 
-        let gridController = ExpandedCollectionViewController(item: item, podcasts: [])
-        gridController.cellStyle = .networkGrid
-        gridController.networks = networks
-        gridController.onSelectNetwork = { [weak self] network in
+        let gridController = DiscoverNetworksGridViewController(item: item, networks: networks) { [weak self] network in
             self?.show(network: network)
         }
-        gridController.registerDiscoverDelegate(delegate)
         delegate.navController()?.pushViewController(gridController, animated: true)
     }
 

--- a/podcasts/DiscoverNetworksListRowView.swift
+++ b/podcasts/DiscoverNetworksListRowView.swift
@@ -89,27 +89,16 @@ struct DiscoverNetworkCard: View {
     /// The side length of the artwork, which the card is as wide as, or `nil` to fill the width it's given.
     var size: CGFloat?
 
+    @Environment(\.sizeCategory) private var sizeCategory
+
     @EnvironmentObject var theme: Theme
 
     var body: some View {
         VStack(spacing: 10) {
             artwork
-            VStack(spacing: 2) {
-                if let title = network.title {
-                    Text(title)
-                        .foregroundStyle(theme.primaryText01)
-                        .font(size: 15, style: .subheadline, weight: .medium)
-                        .kerning(-0.3)
-                        .lineLimit(1)
-                }
-                if let description = network.description {
-                    Text(description)
-                        .foregroundStyle(theme.primaryText02)
-                        .font(size: 14, style: .subheadline, weight: .medium)
-                        .lineLimit(2)
-                }
-            }
-            .multilineTextAlignment(.center)
+            text
+                .multilineTextAlignment(.center)
+                .lineLimit(3)
         }
         .frame(width: size)
         .accessibilityElement()
@@ -127,6 +116,34 @@ struct DiscoverNetworkCard: View {
                 .aspectRatio(1, contentMode: .fit)
                 .clipShape(.circle)
         }
+    }
+
+    /// The name and the description as one text, so that the line limit is theirs to share: a name
+    /// long enough to wrap takes a line the description would have had.
+    private var text: Text {
+        switch (network.title, network.description) {
+        case let (title?, description?):
+            titleText(title) + Text(verbatim: "\n") + descriptionText(description)
+        case let (title?, nil):
+            titleText(title)
+        case let (nil, description?):
+            descriptionText(description)
+        case (nil, nil):
+            Text(verbatim: "")
+        }
+    }
+
+    private func titleText(_ title: String) -> Text {
+        Text(title)
+            .font(.scaled(size: 15, style: .subheadline, weight: .medium, sizeCategory: sizeCategory))
+            .foregroundStyle(theme.primaryText01)
+            .kerning(-0.3)
+    }
+
+    private func descriptionText(_ description: String) -> Text {
+        Text(description)
+            .font(.scaled(size: 14, style: .subheadline, weight: .medium, sizeCategory: sizeCategory))
+            .foregroundStyle(theme.primaryText02)
     }
 }
 

--- a/podcasts/DiscoverNetworksListRowView.swift
+++ b/podcasts/DiscoverNetworksListRowView.swift
@@ -86,41 +86,27 @@ struct DiscoverNetworkCard: View {
 
     let network: NetworkListSummary
 
-    /// The side length of the artwork, which the card is as wide as.
-    let size: CGFloat
+    /// The side length of the artwork, which the card is as wide as, or `nil` to fill the width it's given.
+    var size: CGFloat?
 
     @EnvironmentObject var theme: Theme
 
-    private static let titleSize: CGFloat = 15
-    private static let descriptionSize: CGFloat = 14
-    private static let descriptionLineLimit = 2
-    private static let artworkSpacing: CGFloat = 10
-    private static let textSpacing: CGFloat = 2
-
-    /// The height the name and description take up under the artwork, at the current text size.
-    static var textHeight: CGFloat {
-        let title = UIFont.font(ofSize: titleSize, weight: .medium, scalingWith: .subheadline)
-        let description = UIFont.font(ofSize: descriptionSize, weight: .medium, scalingWith: .subheadline)
-        return ceil(artworkSpacing + title.lineHeight + textSpacing + (CGFloat(descriptionLineLimit) * description.lineHeight))
-    }
-
     var body: some View {
-        VStack(spacing: Self.artworkSpacing) {
-            NetworkArtworkView(url: network.collectionImageURL, size: size)
-                .clipShape(.circle)
-            VStack(spacing: Self.textSpacing) {
+        VStack(spacing: 10) {
+            artwork
+            VStack(spacing: 2) {
                 if let title = network.title {
                     Text(title)
                         .foregroundStyle(theme.primaryText01)
-                        .font(size: Self.titleSize, style: .subheadline, weight: .medium)
+                        .font(size: 15, style: .subheadline, weight: .medium)
                         .kerning(-0.3)
                         .lineLimit(1)
                 }
                 if let description = network.description {
                     Text(description)
                         .foregroundStyle(theme.primaryText02)
-                        .font(size: Self.descriptionSize, style: .subheadline, weight: .medium)
-                        .lineLimit(Self.descriptionLineLimit)
+                        .font(size: 14, style: .subheadline, weight: .medium)
+                        .lineLimit(2)
                 }
             }
             .multilineTextAlignment(.center)
@@ -129,6 +115,18 @@ struct DiscoverNetworkCard: View {
         .accessibilityElement()
         .accessibilityLabel(network.accessibilityLabel)
         .accessibilityAddTraits(.isButton)
+    }
+
+    @ViewBuilder
+    private var artwork: some View {
+        if let size {
+            NetworkArtworkView(url: network.collectionImageURL, size: size)
+                .clipShape(.circle)
+        } else {
+            NetworkArtworkView(url: network.collectionImageURL)
+                .aspectRatio(1, contentMode: .fit)
+                .clipShape(.circle)
+        }
     }
 }
 

--- a/podcasts/DiscoverNetworksListRowView.swift
+++ b/podcasts/DiscoverNetworksListRowView.swift
@@ -81,8 +81,8 @@ struct DiscoverNetworksListRowView: View {
     }
 }
 
-/// A network in the Discover row: round artwork above its name and description.
-private struct DiscoverNetworkCard: View {
+/// A network in the Discover row and in the expanded grid: round artwork above its name and description.
+struct DiscoverNetworkCard: View {
 
     let network: NetworkListSummary
 
@@ -91,23 +91,36 @@ private struct DiscoverNetworkCard: View {
 
     @EnvironmentObject var theme: Theme
 
+    private static let titleSize: CGFloat = 15
+    private static let descriptionSize: CGFloat = 14
+    private static let descriptionLineLimit = 2
+    private static let artworkSpacing: CGFloat = 10
+    private static let textSpacing: CGFloat = 2
+
+    /// The height the name and description take up under the artwork, at the current text size.
+    static var textHeight: CGFloat {
+        let title = UIFont.font(ofSize: titleSize, weight: .medium, scalingWith: .subheadline)
+        let description = UIFont.font(ofSize: descriptionSize, weight: .medium, scalingWith: .subheadline)
+        return ceil(artworkSpacing + title.lineHeight + textSpacing + (CGFloat(descriptionLineLimit) * description.lineHeight))
+    }
+
     var body: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: Self.artworkSpacing) {
             NetworkArtworkView(url: network.collectionImageURL, size: size)
                 .clipShape(.circle)
-            VStack(spacing: 2) {
+            VStack(spacing: Self.textSpacing) {
                 if let title = network.title {
                     Text(title)
                         .foregroundStyle(theme.primaryText01)
-                        .font(size: 15, style: .subheadline, weight: .medium)
+                        .font(size: Self.titleSize, style: .subheadline, weight: .medium)
                         .kerning(-0.3)
                         .lineLimit(1)
                 }
                 if let description = network.description {
                     Text(description)
                         .foregroundStyle(theme.primaryText02)
-                        .font(size: 14, style: .subheadline, weight: .medium)
-                        .lineLimit(2)
+                        .font(size: Self.descriptionSize, style: .subheadline, weight: .medium)
+                        .lineLimit(Self.descriptionLineLimit)
                 }
             }
             .multilineTextAlignment(.center)
@@ -116,23 +129,6 @@ private struct DiscoverNetworkCard: View {
         .accessibilityElement()
         .accessibilityLabel(network.accessibilityLabel)
         .accessibilityAddTraits(.isButton)
-    }
-}
-
-/// A network as a poster: its artwork, with the name and description read out by VoiceOver.
-struct DiscoverNetworkPoster: View {
-
-    let network: NetworkListSummary
-
-    /// A fixed side length, or `nil` for the poster to fill the space it's given.
-    var size: CGFloat?
-
-    var body: some View {
-        NetworkArtworkView(url: network.collectionImageURL, size: size)
-            .cornerRadius(4)
-            .accessibilityElement()
-            .accessibilityLabel(network.accessibilityLabel)
-            .accessibilityAddTraits(.isButton)
     }
 }
 
@@ -179,7 +175,7 @@ struct NetworkArtworkView: View {
     }
 }
 
-private extension NetworkListSummary {
+extension NetworkListSummary {
     var accessibilityLabel: String {
         [title, description].compactMap { $0 }.joined(separator: ", ")
     }

--- a/podcasts/ExpandedCollectionViewController+CollectionView.swift
+++ b/podcasts/ExpandedCollectionViewController+CollectionView.swift
@@ -39,7 +39,9 @@ extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollec
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ExpandedCollectionViewController.networkCellId, for: indexPath)
             let network = networks[indexPath.row]
             cell.contentConfiguration = UIHostingConfiguration {
-                DiscoverNetworkPoster(network: network)
+                DiscoverNetworkCard(network: network, size: networkItemSize(in: collectionView).width)
+                    .frame(maxHeight: .infinity, alignment: .top)
+                    .environmentObject(Theme.sharedTheme)
             }
             .margins(.all, 0)
             return cell
@@ -103,26 +105,29 @@ extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollec
         }
     }
 
-    /// Network posters are square: unlike a podcast, the title is drawn over the artwork.
+    /// A network cell is its round artwork, as wide as the column, with the name and description below it.
     func networkItemSize(in collectionView: UICollectionView) -> CGSize {
-        let viewWidth = collectionView.bounds.width - (2 * inset)
-        let numColumns = max(gridNumColumns, floor(viewWidth / (networkGridPreferredWidth + gridStyleSpacing)))
-        let itemWidth = (viewWidth - (gridStyleSpacing * (numColumns - 1))) / numColumns
+        let viewWidth = collectionView.bounds.width - (2 * networkGridInset)
+        let numColumns = max(gridNumColumns, floor(viewWidth / (networkGridPreferredWidth + networkGridSpacing)))
+        let itemWidth = (viewWidth - (networkGridSpacing * (numColumns - 1))) / numColumns
 
-        return CGSize(width: itemWidth, height: itemWidth)
+        return CGSize(width: itemWidth, height: itemWidth + DiscoverNetworkCard.textHeight)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        let topInset = (podcastCollection == nil && cellStyle != .descriptiveList) ? inset : 0
-        return UIEdgeInsets(top: topInset, left: inset, bottom: 0, right: inset)
+        let horizontalInset = cellStyle == .networkGrid ? networkGridInset : inset
+        let topInset = (podcastCollection == nil && cellStyle != .descriptiveList) ? horizontalInset : 0
+        return UIEdgeInsets(top: topInset, left: horizontalInset, bottom: 0, right: horizontalInset)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         switch cellStyle {
         case .descriptiveList:
             return 0
-        case .grid, .networkGrid:
+        case .grid:
             return inset
+        case .networkGrid:
+            return networkGridLineSpacing
         }
     }
 

--- a/podcasts/ExpandedCollectionViewController+CollectionView.swift
+++ b/podcasts/ExpandedCollectionViewController+CollectionView.swift
@@ -1,8 +1,8 @@
-import SwiftUI
+import UIKit
 
 extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        cellStyle == .networkGrid ? networks.count : podcasts.count
+        podcasts.count
     }
 
     // MARK: - CollectionView Datasource
@@ -35,26 +35,10 @@ extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollec
                 }
             }
             return cell
-        case .networkGrid:
-            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ExpandedCollectionViewController.networkCellId, for: indexPath)
-            let network = networks[indexPath.row]
-            cell.contentConfiguration = UIHostingConfiguration {
-                DiscoverNetworkCard(network: network, size: networkItemSize(in: collectionView).width)
-                    .frame(maxHeight: .infinity, alignment: .top)
-                    .environmentObject(Theme.sharedTheme)
-            }
-            .margins(.all, 0)
-            return cell
         }
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        if cellStyle == .networkGrid {
-            onSelectNetwork?(networks[indexPath.row])
-            collectionView.deselectItem(at: indexPath, animated: true)
-            return
-        }
-
         let podcast = podcasts[indexPath.row]
         delegate?.show(discoverPodcast: podcast, placeholderImage: nil, isFeatured: false, listUuid: item.uuid)
         collectionView.deselectItem(at: indexPath, animated: true)
@@ -100,25 +84,12 @@ extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollec
             let numColumns = isBigDevice ? floor(viewWidth / (gridPreferredWidth + gridStyleSpacing)) : gridNumColumns
             let itemWidth = (viewWidth - (gridStyleSpacing * (numColumns - 1))) / numColumns
             return CGSize(width: itemWidth, height: itemWidth + cellExtraHeight)
-        case .networkGrid:
-            return networkItemSize(in: collectionView)
         }
     }
 
-    /// A network cell is its round artwork, as wide as the column, with the name and description below it.
-    func networkItemSize(in collectionView: UICollectionView) -> CGSize {
-        let viewWidth = collectionView.bounds.width - (2 * networkGridInset)
-        let numColumns = max(gridNumColumns, floor(viewWidth / (networkGridPreferredWidth + networkGridSpacing)))
-        let itemWidth = (viewWidth - (networkGridSpacing * (numColumns - 1))) / numColumns
-
-        return CGSize(width: itemWidth, height: itemWidth + DiscoverNetworkCard.textHeight)
-    }
-
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        let horizontalInset = cellStyle == .networkGrid ? networkGridInset : inset
-        let topInset = (podcastCollection == nil && cellStyle != .descriptiveList) ? horizontalInset : 0
-        let bottomInset = cellStyle == .networkGrid ? networkGridInset : 0
-        return UIEdgeInsets(top: topInset, left: horizontalInset, bottom: bottomInset, right: horizontalInset)
+        let topInset = (podcastCollection == nil && cellStyle != .descriptiveList) ? inset : 0
+        return UIEdgeInsets(top: topInset, left: inset, bottom: 0, right: inset)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
@@ -127,8 +98,6 @@ extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollec
             return 0
         case .grid:
             return inset
-        case .networkGrid:
-            return networkGridLineSpacing
         }
     }
 

--- a/podcasts/ExpandedCollectionViewController+CollectionView.swift
+++ b/podcasts/ExpandedCollectionViewController+CollectionView.swift
@@ -117,7 +117,8 @@ extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollec
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         let horizontalInset = cellStyle == .networkGrid ? networkGridInset : inset
         let topInset = (podcastCollection == nil && cellStyle != .descriptiveList) ? horizontalInset : 0
-        return UIEdgeInsets(top: topInset, left: horizontalInset, bottom: 0, right: horizontalInset)
+        let bottomInset = cellStyle == .networkGrid ? networkGridInset : 0
+        return UIEdgeInsets(top: topInset, left: horizontalInset, bottom: bottomInset, right: horizontalInset)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {

--- a/podcasts/ExpandedCollectionViewController.swift
+++ b/podcasts/ExpandedCollectionViewController.swift
@@ -3,7 +3,7 @@ import SafariServices
 import UIKit
 
 enum CollectionCellStyle {
-    case grid, descriptiveList, networkGrid
+    case grid, descriptiveList
 }
 
 class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDelegate {
@@ -14,20 +14,11 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
 
     var cellStyle: CollectionCellStyle = .grid
 
-    /// The networks drawn in place of `podcasts` when ``cellStyle`` is `networkGrid`.
-    var networks: [NetworkListSummary] = []
-
-    var onSelectNetwork: ((NetworkListSummary) -> Void)?
-
     let inset: CGFloat = 16
     let bigDevicePortraitWidth: CGFloat = 500
     let gridStyleSpacing: CGFloat = 16
     let gridNumColumns: CGFloat = 2
     let gridPreferredWidth: CGFloat = 150
-    let networkGridPreferredWidth: CGFloat = 180
-    let networkGridInset: CGFloat = 24
-    let networkGridSpacing: CGFloat = 18
-    let networkGridLineSpacing: CGFloat = 24
     let gridPeferredHeight: CGFloat = 265
     let descriptiveListPreferredMaxWidth: CGFloat = 280
     var descriptiveListPreferredMaxHeight: CGFloat {
@@ -46,8 +37,7 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
             collectionView.register(UINib(nibName: "LargeListCell", bundle: nil), forCellWithReuseIdentifier: ExpandedCollectionViewController.gridCellId)
             collectionView.register(UINib(nibName: "DescriptiveCollectionCell", bundle: nil), forCellWithReuseIdentifier: ExpandedCollectionViewController.descriptiveCellId)
             collectionView.register(UINib(nibName: "DiscoverCollectionHeader", bundle: nil), forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: ExpandedCollectionViewController.headerId)
-            collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: ExpandedCollectionViewController.networkCellId)
-            collectionView.style = .primaryUi02
+                collectionView.style = .primaryUi02
         }
     }
 
@@ -55,7 +45,6 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
     static let headerId = "DiscoverCollectionHeader"
     static let gridCellId = "LargeListCell"
     static let descriptiveCellId = "DescriptiveCollectionCell"
-    static let networkCellId = "NetworkGridCell"
     private var lastWillLayoutWidth: CGFloat = 0
 
     init(item: DiscoverItem, podcasts: [DiscoverPodcast]) {
@@ -207,20 +196,6 @@ private let previewCollectionImage = "https://static.pocketcasts.com/discover/im
             podcasts: DiscoverPreviewData.podcasts(12)
         )
         controller.cellStyle = .descriptiveList
-        return controller
-    }
-    .ignoresSafeArea()
-}
-
-/// The grid a `lists_list` row opens: networks rather than podcasts, and no collection header.
-#Preview("Networks") {
-    ExpandedCollectionPreview {
-        let controller = ExpandedCollectionViewController(
-            item: DiscoverPreviewData.item(.networksList, title: "Networks"),
-            podcasts: []
-        )
-        controller.cellStyle = .networkGrid
-        controller.networks = DiscoverPreviewData.networkCollection(title: "Networks").lists
         return controller
     }
     .ignoresSafeArea()

--- a/podcasts/ExpandedCollectionViewController.swift
+++ b/podcasts/ExpandedCollectionViewController.swift
@@ -25,6 +25,9 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
     let gridNumColumns: CGFloat = 2
     let gridPreferredWidth: CGFloat = 150
     let networkGridPreferredWidth: CGFloat = 180
+    let networkGridInset: CGFloat = 24
+    let networkGridSpacing: CGFloat = 18
+    let networkGridLineSpacing: CGFloat = 24
     let gridPeferredHeight: CGFloat = 265
     let descriptiveListPreferredMaxWidth: CGFloat = 280
     var descriptiveListPreferredMaxHeight: CGFloat {

--- a/podcasts/SwiftUI+Previews.swift
+++ b/podcasts/SwiftUI+Previews.swift
@@ -25,6 +25,25 @@ extension View {
     func previewOnAllDevices(with theme: Theme.ThemeType = .light) -> some View {
         modifier(PocketCastsPreviewer.allDevices(with: theme))
     }
+
+    /// Theme the preview from its appearance, so Xcode's Color Scheme variants switch the app's theme with them.
+    ///
+    /// The app draws its own colours, so a preview otherwise stays in whatever theme it was given whichever
+    /// appearance the canvas is set to.
+    func previewFollowingAppearance() -> some View {
+        modifier(AppearanceTheme())
+    }
+}
+
+private struct AppearanceTheme: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+
+    private static let light = Theme(previewTheme: .light)
+    private static let dark = Theme(previewTheme: .dark)
+
+    func body(content: Content) -> some View {
+        content.setupDefaultEnvironment(theme: colorScheme == .dark ? Self.dark : Self.light)
+    }
 }
 
 // MARK: - Preview View Modifier

--- a/podcasts/UIFont+FontStyle.swift
+++ b/podcasts/UIFont+FontStyle.swift
@@ -58,6 +58,29 @@ public extension View {
     }
 }
 
+public extension Font {
+    /// The font `View.font(size:style:weight:)` applies, for where a `Font` is needed instead: styling
+    /// the parts of a concatenated `Text`, say.
+    static func scaled(size: Double? = nil,
+                       style: Font.TextStyle,
+                       weight: Font.Weight = .regular,
+                       design: Font.Design? = nil,
+                       sizeCategory: ContentSizeCategory,
+                       maxSizeCategory: UIContentSizeCategory = .accessibilityExtraExtraExtraLarge) -> Font {
+        // Setup the metrics for the font style we'll scale with
+        let metrics = UIFontMetrics(forTextStyle: style.UIFontTextStyle)
+        let size = size ?? UIFont.pointSize(for: style.UIFontTextStyle, sizeCategory: UIContentSizeCategory.large)
+
+        // Scale the given point size up to the largest size that we'll allow
+        let maxPointSize = metrics.scaledValue(for: size, compatibleWith: UITraitCollection(preferredContentSizeCategory: maxSizeCategory))
+
+        // Scale the point size to the current size category, then limit it to the maximum point size
+        let scaledSize = min(maxPointSize, metrics.scaledValue(for: size, compatibleWith: sizeCategory.traitCollection))
+
+        return .system(size: scaledSize, weight: weight, design: design)
+    }
+}
+
 private struct DynamicallyScalableFont: ViewModifier {
     @Environment(\.sizeCategory) var sizeCategory
 
@@ -68,19 +91,7 @@ private struct DynamicallyScalableFont: ViewModifier {
     var maxSizeCategory: UIContentSizeCategory = .accessibilityExtraExtraExtraLarge
 
     func body(content: Content) -> some View {
-        // Setup the metrics for the font style we'll scale with
-        let metrics = UIFontMetrics(forTextStyle: style.UIFontTextStyle)
-        let traits = sizeCategory.traitCollection
-        let size = self.size ?? UIFont.pointSize(for: style.UIFontTextStyle, sizeCategory: UIContentSizeCategory.large)
-
-        // Scale the given point size up to the largest size that we'll allow
-        let maxPointSize = metrics.scaledValue(for: size, compatibleWith: UITraitCollection(preferredContentSizeCategory: maxSizeCategory))
-
-        // Scale the point size to the current size category, then limit it to the maximum point size
-        let scaledSize = min(maxPointSize, metrics.scaledValue(for: size, compatibleWith: traits))
-
-        // Return the new calculated font
-        return content.font(.system(size: scaledSize, weight: weight, design: design))
+        content.font(.scaled(size: size, style: style, weight: weight, design: design, sizeCategory: sizeCategory, maxSizeCategory: maxSizeCategory))
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-944

Restyles the networks grid that "Show all" opens to match [Figma](https://www.figma.com/design/6lHanG1akxKivxjRmlusVR/Netowrk-Discovery?node-id=386-28146&m=dev): round artwork with the name and description below it.

It's now SwiftUI (`DiscoverNetworksGridView`) rather than a `networkGrid` cell style on `ExpandedCollectionViewController`, which had to be told each cell's height up front and cut the description to one line when that estimate came up short. A `LazyVGrid` sizes its own rows, so Dynamic Type just works. The name and description are one text with a three line limit, so a name that wraps takes a line from the description.

Previews also get the networks the live list carries, in place of sleep podcast artwork with unrelated names.

## To test

1. Open Discover, scroll to the **Networks** row and tap **Show all**: two to a row, round artwork with the name and description centred underneath, last row clear of the mini player.
2. Tap a network — it opens its list as before, and the nav bar share button still works.
3. Set **Larger Text** to an accessibility size and repeat: rows grow with the text and the description keeps its lines.
4. Switch to a dark theme and check the grid's colours.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

## Screenshots

Fixed an issue with title being limited to a single line.

<img width="619" height="651" alt="Screenshot 2026-09-04 at 10 02 28 AM" src="https://github.com/user-attachments/assets/384e89dc-e461-4055-9460-0faf0e8c8d98" />


And some other Dynamic Type improvements.

<img width="1525" height="898" alt="Screenshot 2026-09-04 at 10 33 43 AM" src="https://github.com/user-attachments/assets/2431f40e-6cd4-4ab6-b726-5ea9f67d33ab" />
hub.com/user-attachments/assets/44968c92-cf0a-40aa-9b57-ecf4b0a35c7d" />
<img width="836" height="853" alt="Screenshot 2026-09-04 at 10 23 08 AM" src="https://github.com/user-attachments/assets/c6d481b7-ddad-40c6-8704-133601681321" />
