### PR TITLE
Match Figma for the network details screen

### DIFF
--- a/PocketCastsTests/Tests/Discover/NetworkNavigatorTests.swift
+++ b/PocketCastsTests/Tests/Discover/NetworkNavigatorTests.swift
@@ -70,7 +70,7 @@ final class NetworkNavigatorTests: XCTestCase {
         XCTAssertEqual(navigationController.pushedViewControllers.count, 1)
         XCTAssertEqual(serverHandler.requestedSources, [source])
         XCTAssertEqual(pushed.item.uuid, listId)
-        XCTAssertEqual(pushed.item.expandedStyle, "grid")
+        XCTAssertEqual(pushed.item.expandedStyle, "network_grid")
     }
 
     func testTappingTheSameNetworkTwiceLoadsAndShowsItOnce() {

--- a/podcasts/DiscoverCollectionHeader.swift
+++ b/podcasts/DiscoverCollectionHeader.swift
@@ -184,4 +184,3 @@ class DiscoverCollectionHeader: UICollectionReusableView {
         setSubtitleColor()
     }
 }
-

--- a/podcasts/DiscoverCollectionHeader.swift
+++ b/podcasts/DiscoverCollectionHeader.swift
@@ -27,17 +27,11 @@ class DiscoverCollectionHeader: UICollectionReusableView {
     @IBOutlet var avatarBorderView: ThemeableView! {
         didSet {
             avatarBorderView.layer.cornerRadius = 44
-        }
-    }
-
-    @IBOutlet var avatarShadowView: UIView! {
-        didSet {
-            avatarShadowView.layer.cornerRadius = 40
-            avatarShadowView.layer.shadowColor = UIColor.black.cgColor
-            avatarShadowView.layer.shadowOffset = CGSize(width: 0, height: 2)
-            avatarShadowView.layer.shadowOpacity = 0.15
-            avatarShadowView.layer.shadowRadius = 4
-            avatarShadowView.layer.shadowPath = UIBezierPath(ovalIn: CGRect(x: 0, y: 0, width: 80, height: 80)).cgPath
+            avatarBorderView.layer.shadowColor = UIColor.black.cgColor
+            avatarBorderView.layer.shadowOffset = CGSize(width: 0, height: 2)
+            avatarBorderView.layer.shadowOpacity = 0.15
+            avatarBorderView.layer.shadowRadius = 4
+            avatarBorderView.layer.shadowPath = UIBezierPath(ovalIn: CGRect(x: 0, y: 0, width: 88, height: 88)).cgPath
         }
     }
 
@@ -190,3 +184,4 @@ class DiscoverCollectionHeader: UICollectionReusableView {
         setSubtitleColor()
     }
 }
+

--- a/podcasts/DiscoverCollectionHeader.xib
+++ b/podcasts/DiscoverCollectionHeader.xib
@@ -38,10 +38,6 @@
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Oap-c4-00b" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
                             <rect key="frame" x="155.5" y="96" width="88" height="88"/>
                             <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gwR-NQ-hKf">
-                                    <rect key="frame" x="4" y="4" width="80" height="80"/>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                </view>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="7cY-eL-Ku5">
                                     <rect key="frame" x="4" y="4" width="80" height="80"/>
                                     <constraints>
@@ -53,13 +49,9 @@
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="88" id="2M4-xE-sEa"/>
-                                <constraint firstItem="gwR-NQ-hKf" firstAttribute="leading" secondItem="7cY-eL-Ku5" secondAttribute="leading" id="FTN-6s-RnO"/>
                                 <constraint firstItem="7cY-eL-Ku5" firstAttribute="centerX" secondItem="Oap-c4-00b" secondAttribute="centerX" id="bav-Kd-vnY"/>
                                 <constraint firstAttribute="width" constant="88" id="mQF-3T-M5A"/>
                                 <constraint firstItem="7cY-eL-Ku5" firstAttribute="centerY" secondItem="Oap-c4-00b" secondAttribute="centerY" id="seR-xa-STf"/>
-                                <constraint firstItem="gwR-NQ-hKf" firstAttribute="top" secondItem="7cY-eL-Ku5" secondAttribute="top" id="uu7-IQ-MA0"/>
-                                <constraint firstItem="gwR-NQ-hKf" firstAttribute="bottom" secondItem="7cY-eL-Ku5" secondAttribute="bottom" id="ySS-Vm-iHa"/>
-                                <constraint firstItem="gwR-NQ-hKf" firstAttribute="trailing" secondItem="7cY-eL-Ku5" secondAttribute="trailing" id="zC0-4i-YrO"/>
                             </constraints>
                         </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="HIGHLIGHT" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ldU-3C-ZOr">
@@ -177,7 +169,6 @@
             <connections>
                 <outlet property="avatarBorderView" destination="Oap-c4-00b" id="gcA-iL-ncZ"/>
                 <outlet property="avatarImageView" destination="7cY-eL-Ku5" id="LXe-g0-nai"/>
-                <outlet property="avatarShadowView" destination="gwR-NQ-hKf" id="ZeY-C4-f3z"/>
                 <outlet property="collageImageView" destination="mvm-o6-mNy" id="u6U-ps-mhY"/>
                 <outlet property="collageTintView" destination="yYb-i1-leb" id="A5E-bf-ig2"/>
                 <outlet property="descriptionLabel" destination="p3W-lx-nAX" id="QLg-FI-p5N"/>

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -109,7 +109,7 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
             Analytics.track(.discoverShowAllTapped, properties: ["list_id": item.inferredListId])
         }
 
-        if item.expandedStyle == "descriptive_list" || item.expandedStyle == "grid" {
+        if item.expandedStyle == "descriptive_list" || item.expandedStyle == "grid" || item.expandedStyle == "network_grid" {
             let collectionListVC = ExpandedCollectionViewController(item: item, podcasts: podcasts)
             collectionListVC.podcastCollection = podcastCollection
             collectionListVC.registerDiscoverDelegate(self)

--- a/podcasts/DiscoverNetworksListModel.swift
+++ b/podcasts/DiscoverNetworksListModel.swift
@@ -85,8 +85,8 @@ class DiscoverNetworksListModel: ObservableObject {
 
     /// The list the network points at, as the `DiscoverItem` the expanded screens expect.
     ///
-    /// A network opens as a `grid`, the style the curated collections already on the feed use, so
-    /// it gets ``ExpandedCollectionViewController`` and its header whatever the entry asks for.
+    /// A network opens as a `network_grid`: ``ExpandedCollectionViewController`` and its header,
+    /// laid out the way a curated collection is, titled the way a network is.
     private func discoverItem(for network: NetworkListSummary) -> DiscoverItem {
         DiscoverItem(
             id: network.uuid,
@@ -94,7 +94,7 @@ class DiscoverNetworksListModel: ObservableObject {
             title: network.title,
             type: network.type,
             summaryStyle: network.summaryStyle,
-            expandedStyle: "grid",
+            expandedStyle: "network_grid",
             source: network.source,
             regions: item?.regions ?? []
         )

--- a/podcasts/DiscoverNetworksListRowView.swift
+++ b/podcasts/DiscoverNetworksListRowView.swift
@@ -96,6 +96,7 @@ struct DiscoverNetworkCard: View {
     var body: some View {
         VStack(spacing: 10) {
             artwork
+                .shadow(color: .black.opacity(0.15), radius: 4, x: 0, y: 2)
             text
                 .multilineTextAlignment(.center)
                 .lineLimit(3)

--- a/podcasts/ExpandedCollectionViewController.swift
+++ b/podcasts/ExpandedCollectionViewController.swift
@@ -67,17 +67,23 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
             controller.updateSize()
         }
 
-        if let collectionSubtitle = podcastCollection?.subtitle?.localized.localizedCapitalized {
-            title = collectionSubtitle
-        } else {
-            title = item.title?.localized.localizedCapitalized
-        }
+        title = navigationTitle
 
         if item.source != nil && item.isAuthenticated == false {
             customRightBtn = UIBarButtonItem(image: UIImage(named: "podcast-share"), style: .plain, target: self, action: #selector(handleShare))
         }
 
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: collectionView)
+    }
+
+    /// A network is titled by its name, the way its header is: its subtitle names its kind, so
+    /// the bar would otherwise read "Network" on every one of them.
+    private var navigationTitle: String? {
+        if item.expandedStyle == "network_grid" {
+            return podcastCollection?.title?.localized ?? item.title?.localized
+        }
+
+        return podcastCollection?.subtitle?.localized.localizedCapitalized ?? item.title?.localized.localizedCapitalized
     }
 
     override func viewWillLayoutSubviews() {
@@ -170,6 +176,7 @@ private struct ExpandedCollectionPreview: UIViewControllerRepresentable {
 }
 
 private let previewCollectionImage = "https://static.pocketcasts.com/discover/images/420/82e37e80-755d-0138-eddc-0acc26574db2.jpg"
+private let previewNetworkImage = "https://static.pocketcasts.com/share/images/979866dc-fcb6-400d-8586-9e5003ef33b8-author.png"
 
 #Preview("Grid") {
     ExpandedCollectionPreview {
@@ -183,6 +190,24 @@ private let previewCollectionImage = "https://static.pocketcasts.com/discover/im
             description: "Twelve shows for winding down, chosen by the people who make Pocket Casts.",
             podcasts: DiscoverPreviewData.podcasts(12),
             collectionImage: previewCollectionImage
+        )
+        return controller
+    }
+    .ignoresSafeArea()
+}
+
+#Preview("Network") {
+    ExpandedCollectionPreview {
+        let controller = ExpandedCollectionViewController(
+            item: DiscoverPreviewData.item(.collectionSummary, title: "Relay", expandedStyle: "network_grid"),
+            podcasts: DiscoverPreviewData.podcasts(12)
+        )
+        controller.podcastCollection = DiscoverPreviewData.podcastCollection(
+            title: "Relay",
+            subtitle: "NETWORK",
+            description: "Independent podcasts about technology and the people who make it.",
+            podcasts: DiscoverPreviewData.podcasts(12),
+            collectionImage: previewNetworkImage
         )
         return controller
     }

--- a/podcasts/NetworkNavigator.swift
+++ b/podcasts/NetworkNavigator.swift
@@ -53,8 +53,8 @@ final class NetworkNavigator: ObservableObject {
         navigationController.pushViewController(controller, animated: true)
     }
 
-    /// The network's list, as the `DiscoverItem` the expanded screen expects. It opens as a `grid`,
-    /// the same way a network opens from the Discover feed.
+    /// The network's list, as the `DiscoverItem` the expanded screen expects. It opens as a
+    /// `network_grid`, the same way a network opens from the Discover feed.
     private func discoverItem(listId: String, title: String?) -> DiscoverItem {
         DiscoverItem(
             id: listId,
@@ -62,7 +62,7 @@ final class NetworkNavigator: ObservableObject {
             title: title,
             type: NetworkListSummary.supportedType,
             summaryStyle: "collection",
-            expandedStyle: "grid",
+            expandedStyle: "network_grid",
             source: ServerHelper.listUrlString(listId: listId),
             regions: []
         )


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-942

Two things the [network discovery spec](https://www.figma.com/design/6lHanG1akxKivxjRmlusVR/Netowrk-Discovery?node-id=137-15156&m=dev) asks for that the app was missing.

### The elevation shadow on network artwork

`#00000026`, offset (0, 2), blur 8. SwiftUI's radius is half of Figma's blur, hence 4.

- **Discover row and grid.** `DiscoverNetworkCard`'s artwork now carries `.shadow(color: .black.opacity(0.15), radius: 4, x: 0, y: 2)`, applied to `artwork` rather than inside it so it covers both the fixed-size card in the row and the fill-width card in the expanded grid.
- **Details header.** `DiscoverCollectionHeader` already had this shadow, but on an inner 80pt view sitting *inside* the 88pt white ring, so it never escaped the avatar. It moves to `avatarBorderView` with an 88pt path, so the whole bordered circle casts it. The inner view existed only to carry the shadow, and the ring already backs the artwork with `primaryUi01`, so it's gone.

### The navigation title on the details screen

The bar read "Network" on every network, because `ExpandedCollectionViewController` titles itself from the collection's subtitle — which for a curated list is its name ("Staff Picks"), but for a network is its kind. Figma titles the screen with the network's name.

Both places that open a network were laundering its `network_grid` expanded style into `grid` to reach that screen, which threw away the only signal that this is a network. They now pass `network_grid` through, the router treats it as a grid alongside `grid`, and the screen titles itself with the network's name. The name is used verbatim rather than `localizedCapitalized`, which would turn "WNYC" into "Wnyc". Curated collections are untouched.

Adds a "Network" preview next to the existing ones.

## To test

1. Open Discover and scroll to a "Networks" row.
2. Confirm each round network artwork has a soft shadow beneath it.
3. Tap **Show all** and confirm the same shadow on the grid cards.
4. Tap a network. Confirm the navigation bar shows the network's name, and that the shadow falls outside the white ring around its avatar.
5. Back out and open a curated collection ("Featured", "Staff Picks", …) to confirm its navigation title is unchanged.
6. Switch between light and dark themes and confirm both still read correctly.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TC9MKyZ1dhTT2ta21R68xv