### PR TITLE
Run the network header collage under the navigation bar

### DIFF
--- a/podcasts/DiscoverCollectionHeader.swift
+++ b/podcasts/DiscoverCollectionHeader.swift
@@ -18,6 +18,17 @@ class DiscoverCollectionHeader: UICollectionReusableView {
         }
     }
 
+    @IBOutlet var collageTopConstraint: NSLayoutConstraint!
+
+    /// How far the collage runs above the header, so that it fills the space behind the
+    /// navigation bar. Its bottom is pinned to the header, so the avatar and everything
+    /// below it stay put however far it bleeds.
+    var collageTopBleed: CGFloat = 0 {
+        didSet {
+            collageTopConstraint.constant = -collageTopBleed
+        }
+    }
+
     @IBOutlet var avatarImageView: UIImageView! {
         didSet {
             avatarImageView.layer.cornerRadius = 40

--- a/podcasts/DiscoverCollectionHeader.xib
+++ b/podcasts/DiscoverCollectionHeader.xib
@@ -11,7 +11,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <collectionReusableView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="DiscoverCollectionHeader" id="U6b-Vx-4bR" customClass="DiscoverCollectionHeader" customModule="podcasts" customModuleProvider="target">
+        <collectionReusableView opaque="NO" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="DiscoverCollectionHeader" id="U6b-Vx-4bR" customClass="DiscoverCollectionHeader" customModule="podcasts" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="399" height="425"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
@@ -21,15 +21,9 @@
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7eV-el-4ft">
                             <rect key="frame" x="0.0" y="0.0" width="399" height="140"/>
                             <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="140" id="cJp-ck-eqO"/>
-                            </constraints>
                         </view>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="mvm-o6-mNy">
                             <rect key="frame" x="0.0" y="0.0" width="399" height="140"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="140" id="kf7-KT-s9v"/>
-                            </constraints>
                         </imageView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yYb-i1-leb">
                             <rect key="frame" x="0.0" y="0.0" width="399" height="140"/>
@@ -141,6 +135,7 @@
                         <constraint firstItem="ldU-3C-ZOr" firstAttribute="leading" secondItem="7JV-U8-0zd" secondAttribute="leading" constant="16" id="Bqh-Nz-7tE"/>
                         <constraint firstItem="ldU-3C-ZOr" firstAttribute="trailing" secondItem="7JV-U8-0zd" secondAttribute="trailing" constant="-16" id="Cvr-Kd-9pS"/>
                         <constraint firstItem="e6f-hB-C8a" firstAttribute="leading" secondItem="7JV-U8-0zd" secondAttribute="leading" constant="20" symbolic="YES" id="D2m-YL-tqn"/>
+                        <constraint firstItem="7eV-el-4ft" firstAttribute="bottom" secondItem="7JV-U8-0zd" secondAttribute="top" constant="140" id="Hbl-3d-CoL"/>
                         <constraint firstItem="7eV-el-4ft" firstAttribute="top" secondItem="7JV-U8-0zd" secondAttribute="top" id="Lei-T2-pmK"/>
                         <constraint firstItem="yYb-i1-leb" firstAttribute="trailing" secondItem="7eV-el-4ft" secondAttribute="trailing" id="RJJ-ct-HwH"/>
                         <constraint firstItem="yYb-i1-leb" firstAttribute="top" secondItem="7eV-el-4ft" secondAttribute="top" id="Vef-W5-Ygv"/>
@@ -170,6 +165,7 @@
                 <outlet property="avatarBorderView" destination="Oap-c4-00b" id="gcA-iL-ncZ"/>
                 <outlet property="avatarImageView" destination="7cY-eL-Ku5" id="LXe-g0-nai"/>
                 <outlet property="collageImageView" destination="mvm-o6-mNy" id="u6U-ps-mhY"/>
+                <outlet property="collageTopConstraint" destination="Lei-T2-pmK" id="Kd9-Vb-2Nt"/>
                 <outlet property="collageTintView" destination="yYb-i1-leb" id="A5E-bf-ig2"/>
                 <outlet property="descriptionLabel" destination="p3W-lx-nAX" id="QLg-FI-p5N"/>
                 <outlet property="headerView" destination="7JV-U8-0zd" id="GW6-ZP-kpA"/>

--- a/podcasts/ExpandedCollectionViewController+CollectionView.swift
+++ b/podcasts/ExpandedCollectionViewController+CollectionView.swift
@@ -63,6 +63,7 @@ extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollec
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: ExpandedCollectionViewController.headerId, for: indexPath) as! DiscoverCollectionHeader
         header.populate(podcastCollection: podcastCollection)
+        header.collageTopBleed = headerCollageBleed
         header.linkDelegate = self
         return header
     }

--- a/podcasts/ExpandedCollectionViewController.swift
+++ b/podcasts/ExpandedCollectionViewController.swift
@@ -69,6 +69,18 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
 
         title = navigationTitle
 
+        if hasBleedingHeader {
+            navTitleLabel.text = navigationTitle
+            navTitleLabel.textColor = ThemeColor.primaryText01()
+            navigationItem.titleView = {
+                // The label has to go inside a container view, otherwise the bar changes its alpha
+                let container = UIView()
+                container.addSubview(navTitleLabel)
+                navTitleLabel.anchorToAllSidesOf(view: container)
+                return container
+            }()
+        }
+
         if item.source != nil && item.isAuthenticated == false {
             customRightBtn = UIBarButtonItem(image: UIImage(named: "podcast-share"), style: .plain, target: self, action: #selector(handleShare))
         }
@@ -86,6 +98,78 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
         return podcastCollection?.subtitle?.localized.localizedCapitalized ?? item.title?.localized.localizedCapitalized
     }
 
+    /// True when the header's collage fills the space behind the navigation bar. Pre-26 bars are
+    /// opaque, so there'd be nothing to see behind them, and a header-less screen has no collage.
+    private var hasBleedingHeader: Bool {
+        LiquidGlass.isEnabled && podcastCollection != nil
+    }
+
+    /// How far the header's collage runs above the content, so it fills the space behind the bar.
+    var headerCollageBleed: CGFloat {
+        hasBleedingHeader ? view.safeAreaInsets.top : 0
+    }
+
+    private var visibleHeader: DiscoverCollectionHeader? {
+        collectionView.visibleSupplementaryViews(ofKind: UICollectionView.elementKindSectionHeader).first as? DiscoverCollectionHeader
+    }
+
+    /// Where one of the header's views ends in this controller's coordinates, or the very top once
+    /// the header has scrolled away.
+    private func headerBottom(of subview: UIView?) -> CGFloat {
+        guard let subview else { return 0 }
+
+        return subview.convert(CGPoint(x: 0, y: subview.bounds.maxY), to: view).y
+    }
+
+    /// The collage gives the bar no background of its own, so the network's name would sit dark on
+    /// dark. It fades in once the header's own title has scrolled under the bar instead.
+    private lazy var navTitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 17, weight: .semibold)
+        label.textAlignment = .center
+        label.alpha = 0
+        return label
+    }()
+
+    private var isShowingNavTitle = false
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard hasBleedingHeader else { return }
+
+        updateStatusBarStyle()
+
+        let shouldShow = headerBottom(of: visibleHeader?.titleLabel) < view.safeAreaInsets.top
+        guard shouldShow != isShowingNavTitle else { return }
+
+        isShowingNavTitle = shouldShow
+        UIView.animate(withDuration: Constants.Animation.defaultAnimationTime) {
+            self.navTitleLabel.alpha = shouldShow ? 1 : 0
+        }
+    }
+
+    private var isStatusBarLight = false
+
+    /// The collage is dark whichever theme is on, so the status bar takes its light style for as
+    /// long as the collage is behind it.
+    private func updateStatusBarStyle() {
+        let statusBarHeight = view.window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
+        let isLight = hasBleedingHeader && headerBottom(of: visibleHeader?.collageImageView) > statusBarHeight
+        guard isLight != isStatusBarLight else { return }
+
+        isStatusBarLight = isLight
+        setNeedsStatusBarAppearanceUpdate()
+    }
+
+    override func handleThemeChanged() {
+        navTitleLabel.textColor = ThemeColor.primaryText01()
+    }
+
+    override func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+
+        visibleHeader?.collageTopBleed = headerCollageBleed
+    }
+
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
 
@@ -93,6 +177,12 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
             lastWillLayoutWidth = view.bounds.width
             updateFlowLayoutSize()
         }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        updateStatusBarStyle()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -124,7 +214,7 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        AppTheme.defaultStatusBarStyle()
+        isStatusBarLight ? .lightContent : AppTheme.defaultStatusBarStyle()
     }
 
     @objc func handleShare() {
@@ -169,7 +259,11 @@ private struct ExpandedCollectionPreview: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UINavigationController {
         let controller = makeController()
         controller.registerDiscoverDelegate(delegate)
-        return PCNavigationController(rootViewController: controller)
+
+        // Pushed rather than made the root, so the preview carries the back button the real one has.
+        let navigationController = PCNavigationController(rootViewController: UIViewController())
+        navigationController.pushViewController(controller, animated: false)
+        return navigationController
     }
 
     func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {}


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Runs the collection header's collage up to the top of the screen so it sits behind the transparent iOS 26 navigation bar, instead of starting below it.

The collage strip's fixed 140pt height is replaced by a constraint pinning its *bottom* 140pt below the header's top, so only its top constant moves. `collageTopBleed` pulls that top up by the safe-area inset. The avatar, subtitle, title and description are all measured from the strip's bottom, so nothing below it shifts and the header's height is unchanged.

Gated on `LiquidGlass.isEnabled && podcastCollection != nil`: pre-26 bars are opaque so there'd be nothing to see behind them, and a header-less screen (descriptive list) has no collage.

Two knock-on fixes the dark strip forces:

- **Navigation title** would sit dark on dark. It now lives in a `titleView` label that fades in once the header's own title scrolls under the bar — the pattern `PodcastViewController` and `PlaylistDetailViewController` already use.
- **Status bar** takes `.lightContent` while the collage is behind it.

Both thresholds are measured off the live header — `headerBottom(of:)` converts one of its subviews into the controller's coordinates — rather than off hardcoded heights, so they flip at the right moment at any Dynamic Type size and revert once the header scrolls away.

Also pushes the controller onto a root controller in the previews instead of making it the root, so previews carry the back button the real screen has.

## To test

1. Discover → scroll to the networks row → tap a network.
2. The dark collage runs to the top of the screen, behind the navigation bar — no white band above it.
3. The avatar, "NETWORK", the name and the description sit exactly where they did before.
4. The status bar glyphs are light over the collage, and go back to the theme's style once you scroll past it.
5. The navigation bar has no title at rest; scroll until the header's own title passes under the bar and the network name fades in there.
6. Pull down past the top and let go — the collage returns to the top edge.
7. Repeat 1–5 in a dark theme, and at a large Dynamic Type size.
8. Discover → a curated collection ("Show all" on a collection row) gets the same treatment.
9. Discover → a `descriptive_list` item still has no header, and keeps its always-visible navigation title.
10. On iOS 18, every one of these screens looks the way it did before: opaque bar, collage starting below it.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S86ieisS3zwUkTdF7GvXDv
