### PR TITLE
Fix retain cycle in EpisodeDetailViewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix transcripts not showing for podcasts whose feeds serve them as plain text, such as those hosted on Transistor [#5055](https://github.com/Automattic/pocket-casts-ios/pull/5055)
 - Playback failures caused by a full disk now report a storage error instead of asking you to check your internet connection [#5056](https://github.com/Automattic/pocket-casts-ios/pull/5056)
 - Fix the Chromecast button being invisible in the fullscreen video player [#5060](https://github.com/Automattic/pocket-casts-ios/pull/5060)
+- Fix a memory leak that kept the episode details screen, its views and artwork in memory after it was closed [#5067](https://github.com/Automattic/pocket-casts-ios/pull/5067)
 
 8.20
 -----

--- a/podcasts/Episode/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/Episode/EpisodeDetailViewController+ShowNotes.swift
@@ -52,14 +52,16 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
                     vc?.showNotesWebViewTopConstraint?.constant = 20.0
                 }
                 if let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier, episodeUuid: episodeUUID), !metadata.transcripts.isEmpty {
-                    let viewModel = TranscriptExcerptViewModel(episodeUUID: episodeUUID, podcastUUID: parentIdentifier, isGeneratedTranscript: metadata.hasGeneratedTranscripts) {
-                        DispatchQueue.main.async { [weak self] in
+                    let viewModel = TranscriptExcerptViewModel(episodeUUID: episodeUUID, podcastUUID: parentIdentifier, isGeneratedTranscript: metadata.hasGeneratedTranscripts) { [weak self] in
+                        DispatchQueue.main.async {
+                            guard let self else { return }
+
                             let playbackManager = TranscriptEpisodeInfoProvider(episodeUUID: episodeUUID, podcastUUID: parentIdentifier)
                             let controller = TranscriptContainerViewController(playbackManager: playbackManager)
                             controller.playButtonTapped = { [weak self] playing in
                                 self?.playPauseEpisode(isPlaying: playing)
                             }
-                            self?.present(controller, animated: true)
+                            self.present(controller, animated: true)
                         }
                     }
                     await MainActor.run { [weak self] in

--- a/podcasts/Episode/EpisodeDetailViewController.swift
+++ b/podcasts/Episode/EpisodeDetailViewController.swift
@@ -119,8 +119,8 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
 
     @IBOutlet var messageView: RoundedBorderView! {
         didSet {
-            messageView.getBorderColor = { AppTheme.episodeMessageBorderColor(for: self.themeOverride) }
-            messageView.getBgColor = { AppTheme.episodeMessageBackgroundColor(for: self.themeOverride) }
+            messageView.getBorderColor = { [weak self] in AppTheme.episodeMessageBorderColor(for: self?.themeOverride) }
+            messageView.getBgColor = { [weak self] in AppTheme.episodeMessageBackgroundColor(for: self?.themeOverride) }
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

`EpisodeDetailViewController` leaked on every open — its `deinit` never ran, so the controller, its whole view hierarchy and the loaded artwork stayed in memory. There were two separate retain cycles.

**1. `messageView` color closures** (`EpisodeDetailViewController.swift`)

```swift
messageView.getBorderColor = { AppTheme.episodeMessageBorderColor(for: self.themeOverride) }
```

`RoundedBorderView` stores those closures and the controller strongly owns the view via the outlet: `VC → messageView → closure → VC`.

**2. Transcript excerpt tap action** (`EpisodeDetailViewController+ShowNotes.swift`)

```swift
let viewModel = TranscriptExcerptViewModel(...) {
    DispatchQueue.main.async { [weak self] in ... }
}
```

The outer closure had no capture list, so it captured the strong `self` unwrapped by the enclosing `Task`. The inner `[weak self]` doesn't help — the outer closure still has to hold `self` strongly in order to weakly capture it later. `TranscriptExcerptViewModel` stores it as `private let tapAction`, and the view model is held by the `ThemedHostingController` added with `addChild(vc)`: `VC → child hosting controller → rootView → viewModel → tapAction → VC`.

This one fires whenever `FeatureFlag.episodeDetailTranscript` is on (default `true`) and the episode has transcripts, i.e. most episodes.

Both are fixed by capturing `self` weakly. Behaviour is unchanged — the `AppTheme` helpers already take an optional `Theme.ThemeType?`, and the tap action is a no-op once the controller is gone.

## To test

1. Run the app from Xcode.
2. Open a podcast, tap an episode to show the episode details, then dismiss it. Repeat a few times, using at least one episode that shows the transcript card.
3. Take a memory graph (Debug → Debug Memory Graph) and filter for `EpisodeDetailViewController` — there should be no instances left. Before this change there was one per open.
4. Sanity check the message view still renders with the correct border/background color in light and dark, and from the player (where `themeOverride` is set).
5. Sanity check that tapping the transcript card still opens the transcript, and that its play button still starts/pauses playback.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
