### PR TITLE
Silence non-Sendable AVAssetWriter capture in VideoExporter

### DIFF
--- a/podcasts/Sharing/Clip/VideoExporter.swift
+++ b/podcasts/Sharing/Clip/VideoExporter.swift
@@ -81,6 +81,7 @@ enum VideoExporter {
         videoWriter.startWriting()
         videoWriter.startSession(atSourceTime: .zero)
 
+        let cancellableWriter = UnsafeTransfer(videoWriter)
         try await withTaskCancellationHandler {
             try await writeFrames(of: view,
                                   size: parameters.size,
@@ -92,7 +93,7 @@ enum VideoExporter {
                                   progress: progress,
                                   frameCount: frameCount)
         } onCancel: {
-            videoWriter.cancelWriting()
+            cancellableWriter.wrappedValue.cancelWriting()
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Building the clip sharing code produced:

```
Capture of 'videoWriter' with non-Sendable type 'AVAssetWriter' in a '@Sendable' closure; this is an error in the Swift 6 language mode
```

The `onCancel:` closure of `withTaskCancellationHandler` is `@Sendable`, so it can't capture the `AVAssetWriter` directly. Wrap the writer in `UnsafeTransfer` for the cancellation path — `cancelWriting()` is documented as safe to call from any thread. This mirrors how `AudioClipExporter` already passes its `AVAssetExportSession` into `onCancel:`.

No behaviour change.

## To test

1. Build the app and confirm the warning above no longer appears for `VideoExporter.swift`.
2. Play an episode, tap the share button and choose **Clip**.
3. Select a clip and share it as a video — confirm the video exports and looks correct.
4. Start a clip video export and cancel it mid-export — confirm the export stops cleanly with no crash.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.