### PR TITLE
Fix Hashable violation in PodcastFolderSearchResult

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -97,6 +97,11 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
     public static func ==(lhs: PodcastFolderSearchResult, rhs: PodcastFolderSearchResult) -> Bool {
         lhs.kind == rhs.kind && lhs.uuid == rhs.uuid
     }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(kind)
+        hasher.combine(uuid)
+    }
 }
 
 extension PodcastFolderSearchResult: Identifiable {
@@ -132,8 +137,14 @@ public class PodcastSearchTask {
         if let podcast = envelope?.result.podcast {
             return [podcast]
         } else {
-            return envelope?.result.searchResults ?? []
+            return Self.deduplicated(envelope?.result.searchResults ?? [])
         }
+    }
+
+    /// Drops results the search API repeated, keeping the first of each and the original order.
+    static func deduplicated(_ results: [PodcastFolderSearchResult]) -> [PodcastFolderSearchResult] {
+        var seen = Set<PodcastFolderSearchResult>()
+        return results.filter { seen.insert($0).inserted }
     }
 
     private func search(term: String) async throws -> PodcastsSearchEnvelope {

--- a/Modules/Tests/PocketCastsServerTests/PodcastFolderSearchResultTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/PodcastFolderSearchResultTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+@testable import PocketCastsServer
+import XCTest
+
+final class PodcastFolderSearchResultTests: XCTestCase {
+
+    // MARK: - Hashable
+
+    func testResultsForTheSamePodcastHashTheSame() throws {
+        let remote = try makeResult(uuid: "uuid", title: "Planet Money", author: "NPR", isLocal: false)
+        let local = try makeResult(uuid: "uuid", title: "Planet Money 2", author: "", isLocal: true)
+
+        XCTAssertEqual(remote, local)
+        XCTAssertEqual(remote.hashValue, local.hashValue)
+    }
+
+    func testSetKeepsOneOfTwoResultsForTheSamePodcast() throws {
+        let remote = try makeResult(uuid: "uuid", title: "Planet Money", author: "NPR", isLocal: false)
+        let local = try makeResult(uuid: "uuid", title: "Planet Money 2", author: "", isLocal: true)
+
+        XCTAssertEqual(Set([remote, local]).count, 1)
+    }
+
+    func testAPodcastAndAFolderWithTheSameUUIDStayDistinct() throws {
+        let podcast = try makeResult(uuid: "uuid", title: "Planet Money", kind: .podcast)
+        let folder = try makeResult(uuid: "uuid", title: "Planet Money", kind: .folder)
+
+        XCTAssertNotEqual(podcast, folder)
+        XCTAssertEqual(Set([podcast, folder]).count, 2)
+    }
+
+    // MARK: - Deduplication
+
+    func testDeduplicatedKeepsTheFirstOfEachRepeatedResult() throws {
+        let first = try makeResult(uuid: "1", title: "Planet Money", author: "NPR")
+        let repeated = try makeResult(uuid: "1", title: "Planet Money", author: "NPR Inc")
+        let second = try makeResult(uuid: "2", title: "99% Invisible")
+
+        let results = PodcastSearchTask.deduplicated([first, repeated, second])
+
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results.map(\.uuid), ["1", "2"])
+        XCTAssertEqual(results.first?.author, "NPR")
+    }
+
+    func testDeduplicatedLeavesDistinctResultsUntouched() throws {
+        let results = try [
+            makeResult(uuid: "1", title: "Planet Money"),
+            makeResult(uuid: "2", title: "99% Invisible"),
+            makeResult(uuid: "3", title: "Radiolab")
+        ]
+
+        XCTAssertEqual(PodcastSearchTask.deduplicated(results).map(\.uuid), ["1", "2", "3"])
+    }
+
+    func testDeduplicatedOnEmptyResults() {
+        XCTAssertTrue(PodcastSearchTask.deduplicated([]).isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    /// Builds a result the way the search API does: by decoding it.
+    private func makeResult(
+        uuid: String,
+        title: String,
+        author: String = "",
+        kind: PodcastFolderSearchResult.Kind = .podcast,
+        isLocal: Bool = false
+    ) throws -> PodcastFolderSearchResult {
+        let payload = Payload(uuid: uuid, title: title, author: author, kind: kind, isLocal: isLocal)
+        let data = try JSONEncoder().encode(payload)
+        return try JSONDecoder().decode(PodcastFolderSearchResult.self, from: data)
+    }
+
+    private struct Payload: Encodable {
+        let uuid: String
+        let title: String
+        let author: String
+        let kind: PodcastFolderSearchResult.Kind
+        let isLocal: Bool
+    }
+}

--- a/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
+++ b/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
@@ -1,3 +1,5 @@
+import PocketCastsDataModel
+import PocketCastsServer
 import XCTest
 
 @testable import podcasts
@@ -64,6 +66,21 @@ class SearchHistoryModelTests: XCTestCase {
         model.removeAll()
 
         XCTAssertTrue(model.entries.isEmpty)
+    }
+
+    // MARK: Identity
+
+    func testEntriesForTheSamePodcastHashTheSame() {
+        let podcast = PodcastBuilder().build()
+        podcast.title = "Planet Money"
+        podcast.author = "NPR"
+        let first = SearchHistoryEntry(podcast: PodcastFolderSearchResult(from: podcast))
+
+        podcast.title = "Planet Money 2"
+        let second = SearchHistoryEntry(podcast: PodcastFolderSearchResult(from: podcast))
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.hashValue, second.hashValue)
     }
 
     // MARK: Limit


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes a `EXC_BREAKPOINT` crash reported from `LazyLayoutViewCache.addItem`:

```
Fatal error: Duplicate keys of type 'Canonical' were found in a Dictionary.
This usually means either that the type violates Hashable's requirements, or
that members of such a dictionary were mutated after insertion.
```

`PodcastFolderSearchResult` declares `Hashable` and hand-writes `==` over `kind` and `uuid`, but lets the compiler synthesize `hash(into:)` over all seven stored properties. Two results for the same podcast with a different `title`, `author`, `isLocal`, `explicit` or `isVideo` are therefore equal but hash differently, which makes `Set`/`Dictionary` behaviour undefined.

That type is the identity of `SearchHistoryView`'s `ForEach(searchHistory.entries, id: \.self)` (via `SearchHistoryEntry`), inside the `LazyVStack` in `SearchListView`. `LazyLayoutViewCache` is a dictionary that outlives a single update, so when `SearchHistoryModel.updateFolders()` rewrites a folder entry in place — same uuid, new name — inserting the new key finds the stale-but-equal one during probing and traps. Intermittent, because it depends on the two hashes landing in the same probe run.

This PR adds a `hash(into:)` that matches `==`. It also de-duplicates the results returned by `PodcastSearchTask.search(term:)`: the API can repeat a podcast, and `OnboardingRecommendationsView` feeds that array straight into a `LazyVStack` `ForEach` keyed by uuid, which would crash the same way.

Unit tests cover the hash/equality consistency, the `Set` behaviour, podcast-vs-folder results sharing a uuid, and the de-duplication. Removing `hash(into:)` fails three of them.

## To test

There is no reliable manual repro — the crash depends on hash bucketing. The regression is covered by tests:

1. Run `PocketCastsServerTests/PodcastFolderSearchResultTests` (6 tests).
2. Run `PocketCastsTests/SearchHistoryModelTests` (8 tests).
3. Sanity-check search still behaves: open Search, search for a podcast, tap a result, reopen Search and confirm it shows in Recent.
4. With a Plus account, tap a folder from search results, rename the folder, and reopen Search — the Recent row should show the new name and not crash.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.