### PR TITLE
Soften the network artwork shadow

### DIFF
--- a/podcasts/DiscoverCollectionHeader.swift
+++ b/podcasts/DiscoverCollectionHeader.swift
@@ -27,11 +27,8 @@ class DiscoverCollectionHeader: UICollectionReusableView {
     @IBOutlet var avatarBorderView: ThemeableView! {
         didSet {
             avatarBorderView.layer.cornerRadius = 44
-            avatarBorderView.layer.shadowColor = UIColor.black.cgColor
-            avatarBorderView.layer.shadowOffset = CGSize(width: 0, height: 2)
-            avatarBorderView.layer.shadowOpacity = 0.15
-            avatarBorderView.layer.shadowRadius = 4
-            avatarBorderView.layer.shadowPath = UIBezierPath(ovalIn: CGRect(x: 0, y: 0, width: 88, height: 88)).cgPath
+            avatarBorderView.layer.borderWidth = 1
+            setAvatarBorderColor()
         }
     }
 
@@ -139,6 +136,10 @@ class DiscoverCollectionHeader: UICollectionReusableView {
         setSubtitleColor()
     }
 
+    private func setAvatarBorderColor() {
+        avatarBorderView.layer.borderColor = AppTheme.colorForStyle(.primaryUi05).cgColor
+    }
+
     private func setSubtitleColor() {
         subtitleLabel.textColor = podcastCollection?.colors?.activeThemeColor ?? AppTheme.colorForStyle(.support05)
     }
@@ -182,5 +183,6 @@ class DiscoverCollectionHeader: UICollectionReusableView {
     @objc func themeDidChange() {
         setImageTint()
         setSubtitleColor()
+        setAvatarBorderColor()
     }
 }

--- a/podcasts/DiscoverNetworksListRowView.swift
+++ b/podcasts/DiscoverNetworksListRowView.swift
@@ -96,7 +96,9 @@ struct DiscoverNetworkCard: View {
     var body: some View {
         VStack(spacing: 10) {
             artwork
-                .shadow(color: .black.opacity(0.15), radius: 4, x: 0, y: 2)
+                .overlay {
+                    Circle().strokeBorder(theme.primaryUi05, lineWidth: 1)
+                }
             text
                 .multilineTextAlignment(.center)
                 .lineLimit(3)


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Replace the shadow under the round network artwork with a hairline border, on the Discover cards and grid and on the collection header the cards open into.

<img width="943" height="938" alt="Screenshot 2026-09-09 at 10 10 01 AM" src="https://github.com/user-attachments/assets/d269bf87-5fed-4dc3-8219-39abab60c60f" />


## To test

1. Enable the `networkDiscovery` feature flag.
2. Go to Discover and find the networks row.
3. Check the edge of the round network artwork — it should be a hairline `primaryUi05` ring instead of a drop shadow.
4. Tap a network to open its page and check the large round artwork in the header — it gets the same ring.
5. Open a non-network curated collection too: it shares the same header, so its avatar also gets the ring.
6. Repeat in both light and dark themes.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY4Roe41RWUFLXsQyhrzSv
