### PR TITLE
Add the What's New feed screen

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog+Mock.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog+Mock.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+public extension WhatsNewCatalog {
+    /// A catalog shaped like the published contract, for previews and manual testing.
+    ///
+    /// The messages are published relative to now rather than on fixed dates, so the feed keeps
+    /// rendering the same spread of relative dates however long after this was written it's read.
+    static let mock = mock(publishedDaysAgo: [0, 8, 27, 36, 62])
+
+    /// A catalog whose messages were published the given number of days ago, most recent first.
+    ///
+    /// Trimming or padding the list changes how many messages the catalog carries, so a preview can
+    /// ask for a single message or a feed long enough to scroll.
+    static func mock(publishedDaysAgo: [Int]) -> WhatsNewCatalog {
+        let messages = zip(publishedDaysAgo, mockMessages).map { daysAgo, message in
+            message.replacingOccurrences(of: "$publishedAt", with: iso8601(daysAgo: daysAgo))
+        }
+        let json = """
+        {
+          "schemaVersion": 1,
+          "generatedAt": "\(iso8601(daysAgo: 0))",
+          "platform": "ios",
+          "locale": "en",
+          "messages": [\(messages.joined(separator: ","))]
+        }
+        """
+
+        do {
+            return try decoder.decode(WhatsNewCatalog.self, from: Data(json.utf8))
+        } catch {
+            fatalError("The mock What's New catalog no longer matches the models: \(error)")
+        }
+    }
+
+    private static func iso8601(daysAgo: Int) -> String {
+        let date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: Date()) ?? Date()
+        return ISO8601DateFormatter().string(from: date)
+    }
+
+    /// The messages the mock catalog is built from, each missing the `$publishedAt` the catalog fills in.
+    ///
+    /// The user research message carries a `poll` block the app doesn't model, so anything rendering
+    /// the mock exercises a page that drops a block and still has something left to show.
+    private static let mockMessages = [
+        """
+        {
+          "id": "01K2Y3BQ7C4M8XR5NHVD2WTGJ9",
+          "type": "tip",
+          "publishedAt": "$publishedAt",
+          "targeting": { "audiences": [] },
+          "summary": { "title": "Sort your Up Next", "label": "Tips and Tricks" },
+          "content": {
+            "title": "Sort your Up Next",
+            "pages": [
+              {
+                "blocks": [
+                  { "type": "heading", "level": 2, "text": "Put the queue in the order you want" },
+                  { "type": "paragraph", "content": "Drag an episode by its handle to move it, or sort the whole queue by release date, duration, or the order you added them." },
+                  { "type": "action", "label": "Open Up Next", "url": "pocketcasts://upnext", "style": "primary" }
+                ]
+              }
+            ]
+          }
+        }
+        """,
+        """
+        {
+          "id": "01K2Y3D5J1H7QZP0B6RXKA4N3T",
+          "type": "new_feature",
+          "publishedAt": "$publishedAt",
+          "targeting": { "audiences": ["free", "plus", "patron"] },
+          "summary": { "title": "Introducing Playlists", "label": "New Feature" },
+          "content": {
+            "title": "Introducing Playlists",
+            "pages": [
+              {
+                "blocks": [
+                  { "type": "heading", "level": 2, "text": "Filters are now Playlists" },
+                  { "type": "paragraph", "content": "Build a playlist by hand, or let a smart playlist keep itself up to date from the rules you set." }
+                ]
+              },
+              {
+                "blocks": [
+                  { "type": "action", "label": "Try Playlists", "url": "pocketcasts://playlists", "style": "primary" }
+                ]
+              }
+            ]
+          }
+        }
+        """,
+        """
+        {
+          "id": "01K2Y2CFD0VAWA4N74D3N6JTVK",
+          "type": "research",
+          "publishedAt": "$publishedAt",
+          "targeting": { "audiences": ["free", "future_audience"] },
+          "summary": { "title": "Exploring social features", "label": "User Research" },
+          "content": {
+            "pages": [
+              {
+                "blocks": [
+                  { "type": "paragraph", "content": "Which improvement would make the biggest difference?" },
+                  { "type": "poll", "pollId": "01K2Y2S65F22TQZQJVNAEXQKHT", "question": "What next?", "options": [] },
+                  { "type": "paragraph", "content": "The survey takes about two minutes." }
+                ]
+              }
+            ]
+          }
+        }
+        """,
+        """
+        {
+          "id": "01K2Y3F9V8N2C1LKS7DYE0RQMB",
+          "type": "announcement",
+          "publishedAt": "$publishedAt",
+          "targeting": { "audiences": ["free"] },
+          "summary": { "title": "Ads to support Pocket Casts", "label": "Announcement" },
+          "content": {
+            "title": "Ads to support Pocket Casts",
+            "pages": [
+              {
+                "blocks": [
+                  { "type": "paragraph", "content": "We're adding a small number of ads to the free app so we can keep building Pocket Casts for everyone." },
+                  { "type": "action", "label": "Read the announcement", "url": "https://blog.pocketcasts.com", "style": "secondary" }
+                ]
+              }
+            ]
+          }
+        }
+        """,
+        """
+        {
+          "id": "01K2Y08DAWG9N7XJZX5QTH9Z0K",
+          "type": "new_feature",
+          "publishedAt": "$publishedAt",
+          "targeting": { "audiences": ["free", "plus", "patron"], "minimumAppVersion": null },
+          "summary": {
+            "title": "Introducing episode transcripts",
+            "label": "New Feature",
+            "imageUrl": "https://static.pocketcasts.com/whats-new/media/transcripts-card.webp"
+          },
+          "content": {
+            "title": "Introducing episode transcripts",
+            "pages": [
+              {
+                "blocks": [
+                  { "type": "heading", "level": 2, "text": "Read along while you listen" },
+                  { "type": "paragraph", "content": "Search a transcript and follow the conversation." },
+                  {
+                    "type": "image",
+                    "url": "https://static.pocketcasts.com/whats-new/media/transcripts-detail.webp",
+                    "width": 1200,
+                    "height": 750,
+                    "alt": "Episode transcript open beside the player"
+                  }
+                ]
+              },
+              {
+                "blocks": [
+                  { "type": "action", "label": "Try transcripts", "url": "pocketcasts://podcasts", "style": "primary" }
+                ]
+              }
+            ]
+          }
+        }
+        """
+    ]
+}

--- a/podcasts/Whats New/Feed/WhatsNewFeedView.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedView.swift
@@ -1,3 +1,4 @@
+import Kingfisher
 import PocketCastsServer
 import PocketCastsUtils
 import SwiftUI
@@ -98,7 +99,13 @@ private struct WhatsNewFeedArtworkView: View {
                 .foregroundStyle(.white)
 
             if let imageURL = item.imageURL {
-                AsyncImageView(url: imageURL, cache: ImageManager.sharedManager.discoverCache)
+                KFImage(imageURL)
+                    .targetCache(ImageManager.sharedManager.discoverCache)
+                    .fade(duration: 0.25)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .clipped()
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 4))

--- a/podcasts/Whats New/Feed/WhatsNewFeedView.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedView.swift
@@ -1,0 +1,184 @@
+import PocketCastsServer
+import PocketCastsUtils
+import SwiftUI
+
+/// The What's New feed: every message published for this user, most recently published first.
+struct WhatsNewFeedView: View {
+    @EnvironmentObject private var theme: Theme
+    @ObservedObject var viewModel: WhatsNewFeedViewModel
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(viewModel.items) { item in
+                    Button {
+                        viewModel.select(item)
+                    } label: {
+                        WhatsNewFeedRow(item: item)
+                    }
+                    .buttonStyle(WhatsNewFeedRowButtonStyle())
+
+                    if item.id != viewModel.items.last?.id {
+                        Rectangle()
+                            .fill(theme.primaryUi05)
+                            .frame(height: 1)
+                            .padding(.leading, 16)
+                    }
+                }
+            }
+        }
+        .background(theme.primaryUi02.ignoresSafeArea())
+    }
+}
+
+private struct WhatsNewFeedRow: View {
+    @EnvironmentObject private var theme: Theme
+    @ScaledMetric(relativeTo: .largeTitle) private var artworkSize: CGFloat = 56
+    @ScaledMetric(relativeTo: .caption2) private var unreadIndicatorSize: CGFloat = 8
+
+    let item: WhatsNewFeedItem
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            WhatsNewFeedArtworkView(item: item)
+                .frame(width: artworkSize, height: artworkSize)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(alignment: .center, spacing: 12) {
+                    if let label = item.label {
+                        Text(label.localizedUppercase)
+                            .font(size: 11, style: .caption2, weight: .semibold)
+                            .tracking(0.33)
+                            .foregroundStyle(theme.primaryText02)
+                            .lineLimit(1)
+                    }
+
+                    Spacer(minLength: 0)
+
+                    Text(WhatsNewFeedDateFormatter.string(from: item.publishedAt))
+                        .font(size: 11, style: .caption2, weight: .semibold)
+                        .foregroundStyle(theme.primaryText02)
+                        .lineLimit(1)
+                        .layoutPriority(1)
+
+                    Circle()
+                        .fill(theme.support05)
+                        .frame(width: unreadIndicatorSize, height: unreadIndicatorSize)
+                        .opacity(item.isUnread ? 1 : 0)
+                }
+
+                Text(item.title)
+                    .font(size: 15, style: .subheadline, weight: .medium)
+                    .foregroundStyle(theme.primaryText01)
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+    }
+}
+
+/// The artwork the CDN published for a message, over a fallback the message's type picks.
+private struct WhatsNewFeedArtworkView: View {
+    let item: WhatsNewFeedItem
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: item.type.artworkGradient, startPoint: .topLeading, endPoint: .bottomTrailing)
+
+            Image(systemName: item.type.artworkSymbolName)
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(.white)
+
+            if let imageURL = item.imageURL {
+                AsyncImageView(url: imageURL, cache: ImageManager.sharedManager.discoverCache)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+    }
+}
+
+private struct WhatsNewFeedRowButtonStyle: ButtonStyle {
+    @EnvironmentObject private var theme: Theme
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .background(configuration.isPressed ? theme.primaryUi02Active : theme.primaryUi02)
+    }
+}
+
+private extension WhatsNewMessageType {
+    var artworkGradient: [Color] {
+        switch self {
+        case .tip:
+            [UIColor(hex: "#03A9F4").color, UIColor(hex: "#50D0F1").color]
+        case .newFeature:
+            [UIColor(hex: "#F43769").color, UIColor(hex: "#FB5246").color]
+        case .research:
+            [UIColor(hex: "#6B59C7").color, UIColor(hex: "#BC4E7B").color]
+        case .announcement:
+            [UIColor(hex: "#C9522E").color, UIColor(hex: "#B82E3C").color]
+        case .knownIssue:
+            [UIColor(hex: "#FF9D3B").color, UIColor(hex: "#EB6F4F").color]
+        }
+    }
+
+    var artworkSymbolName: String {
+        switch self {
+        case .tip: "arrow.up.arrow.down"
+        case .newFeature: "list.bullet"
+        case .research: "doc.text"
+        case .announcement: "heart"
+        case .knownIssue: "exclamationmark.triangle"
+        }
+    }
+}
+
+private enum WhatsNewFeedDateFormatter {
+    static func string(from date: Date) -> String {
+        if Calendar.current.isDateInToday(date) {
+            return L10n.today
+        }
+        return (date.isCurrentYear() ? monthDay : monthDayYear).string(from: date)
+    }
+
+    private static let monthDay: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        return formatter
+    }()
+
+    private static let monthDayYear: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d yyyy")
+        return formatter
+    }()
+}
+
+// MARK: - Previews
+
+private extension WhatsNewFeedViewModel {
+    /// The mock catalog with everything but the two most recent messages already read.
+    static var mock: WhatsNewFeedViewModel {
+        let messages = WhatsNewCatalog.mock.messages
+        return WhatsNewFeedViewModel(messages: messages, readMessageIDs: Set(messages.dropFirst(2).map(\.id)))
+    }
+}
+
+#Preview("Feed in a navigation controller") {
+    PCNavigationController(rootViewController: WhatsNewFeedViewController(viewModel: .mock))
+}
+
+struct WhatsNewFeedView_Previews: PreviewProvider {
+    static var previews: some View {
+        WhatsNewFeedView(viewModel: .mock)
+            .previewWithAllThemes()
+    }
+}

--- a/podcasts/Whats New/Feed/WhatsNewFeedViewController.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedViewController.swift
@@ -1,0 +1,46 @@
+import Combine
+import PocketCastsServer
+import SwiftUI
+
+/// Hosts `WhatsNewFeedView` and owns the navigation bar the design puts around it.
+class WhatsNewFeedViewController: PCHostingController<WhatsNewFeedView> {
+    private let viewModel: WhatsNewFeedViewModel
+    private var cancellables = Set<AnyCancellable>()
+
+    init(viewModel: WhatsNewFeedViewModel) {
+        self.viewModel = viewModel
+        super.init(rootView: WhatsNewFeedView(viewModel: viewModel), background: \.primaryUi02)
+    }
+
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = L10n.whatsNew
+        navigationItem.largeTitleDisplayMode = .never
+
+        viewModel.$items
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.updateReadAllButton()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func updateReadAllButton() {
+        guard viewModel.hasUnreadItems else {
+            navigationItem.rightBarButtonItem = nil
+            return
+        }
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            title: L10n.whatsNewFeedReadAll,
+            primaryAction: UIAction { [weak self] _ in
+                self?.viewModel.markAllAsRead()
+            }
+        )
+    }
+}

--- a/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
@@ -1,0 +1,58 @@
+import Foundation
+import PocketCastsServer
+
+/// A single row of the What's New feed.
+struct WhatsNewFeedItem: Identifiable, Hashable {
+    let id: String
+    let type: WhatsNewMessageType
+    let label: String?
+    let title: String
+    let publishedAt: Date
+    let imageURL: URL?
+    var isUnread: Bool
+
+    init(message: WhatsNewMessage, isUnread: Bool) {
+        id = message.id
+        type = message.type
+        label = message.summary.label
+        title = message.summary.title
+        publishedAt = message.publishedAt
+        imageURL = message.summary.imageUrl
+        self.isUnread = isUnread
+    }
+}
+
+/// The messages the What's New feed shows, most recently published first.
+@MainActor
+final class WhatsNewFeedViewModel: ObservableObject {
+    @Published private(set) var items: [WhatsNewFeedItem]
+
+    /// Called with the message a tapped row belongs to.
+    var onSelect: ((WhatsNewFeedItem) -> Void)?
+
+    init(messages: [WhatsNewMessage], readMessageIDs: Set<String> = []) {
+        items = messages
+            .sorted { $0.publishedAt > $1.publishedAt }
+            .map { WhatsNewFeedItem(message: $0, isUnread: !readMessageIDs.contains($0.id)) }
+    }
+
+    var hasUnreadItems: Bool {
+        items.contains { $0.isUnread }
+    }
+
+    func select(_ item: WhatsNewFeedItem) {
+        markAsRead(item.id)
+        onSelect?(item)
+    }
+
+    func markAllAsRead() {
+        for index in items.indices {
+            items[index].isUnread = false
+        }
+    }
+
+    private func markAsRead(_ id: WhatsNewFeedItem.ID) {
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+        items[index].isUnread = false
+    }
+}

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3613,6 +3613,9 @@
 /* Title for the announcement screen that calls out new features. */
 "whats_new" = "What's New";
 
+/* Navigation bar button on the What's New feed that marks every message in the list as read. */
+"whats_new_feed_read_all" = "Read all";
+
 /* Widget prompt title to direct the user to the discover tab to add new podcasts to their queue */
 "widgets_discover_prompt_title" = "Nothing in Up Next";
 


### PR DESCRIPTION
| 📘 Part of: What's New Messages |
|:---:|

Part of PCIOS-926

Adds `WhatsNewFeedView`, the vertical feed list from the [Figma design](https://www.figma.com/design/L6SpjlhZIjI1eGiqPwEMcr/What-s-New-Feed?node-id=58-2896&m=dev), built in SwiftUI and hosted in `WhatsNewFeedViewController`. Nothing references it yet, so it can be reviewed against the design before the entry point (PCIOS-925) and read-state sync (PCIOS-924) land.

- Rows show artwork, type label, published date, title, and an unread dot, driven by `WhatsNewFeedViewModel` over the `WhatsNewMessage` models from #5062. Read state lives only in the view model until PCIOS-924.
- `summary.imageUrl` is optional in the CDN contract, so a message without artwork falls back to a gradient and glyph per type, using the Figma type style colours.
- `WhatsNewCatalog.mock` is new — it decodes an extended copy of #5062's fixture, since the models are `Decodable`-only. It's `public` in `PocketCastsServer` so app-target previews can reach it, which means it ships in release builds; happy to put it behind `#if DEBUG`.
- Loading, empty, and error states and pull-to-refresh aren't in this Figma node and depend on the data source PCIOS-924 defines, so they're left for that issue.

## To test

No entry point yet, so this is reviewed through the previews:

1. Open `podcasts/Whats New/Feed/WhatsNewFeedView.swift` in Xcode and resume the canvas. `WhatsNewFeedView_Previews` renders the feed once per theme — check row colours, unread dots, and dividers.
2. In the "Feed in a navigation controller" preview, tap "Read all" — dots clear and the button disappears. Tap a single row: its dot clears and the button stays until nothing is unread.
3. At the largest accessibility text size, confirm artwork, labels, and two-line titles scale without clipping.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
