### PR TITLE
Add the What's New message detail screen

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog+Mock.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog+Mock.swift
@@ -5,7 +5,7 @@ public extension WhatsNewCatalog {
     ///
     /// The messages are published relative to now rather than on fixed dates, so the feed keeps
     /// rendering the same spread of relative dates however long after this was written it's read.
-    static let mock = mock(publishedDaysAgo: [0, 8, 27, 36, 62])
+    static let mock = mock(publishedDaysAgo: [0, 8, 27, 36, 62, 90])
 
     /// A catalog whose messages were published the given number of days ago, most recent first.
     ///
@@ -39,8 +39,9 @@ public extension WhatsNewCatalog {
 
     /// The messages the mock catalog is built from, each missing the `$publishedAt` the catalog fills in.
     ///
-    /// The user research message carries a `poll` block the app doesn't model, so anything rendering
-    /// the mock exercises a page that drops a block and still has something left to show.
+    /// Between them they cover every message type and every block the app renders. The user research
+    /// message carries a `poll` block the app doesn't model, so anything rendering the mock exercises
+    /// a page that drops a block and still has something left to show.
     private static let mockMessages = [
         """
         {
@@ -158,6 +159,35 @@ public extension WhatsNewCatalog {
               {
                 "blocks": [
                   { "type": "action", "label": "Try transcripts", "url": "pocketcasts://podcasts", "style": "primary" }
+                ]
+              }
+            ]
+          }
+        }
+        """,
+        """
+        {
+          "id": "01K2Y4H2P6R8T0VXZB1DFG3JKM",
+          "type": "known_issue",
+          "publishedAt": "$publishedAt",
+          "targeting": { "audiences": [] },
+          "summary": { "title": "Downloads stalling on cellular", "label": "Known Issue" },
+          "content": {
+            "title": "Downloads stalling on cellular",
+            "pages": [
+              {
+                "blocks": [
+                  {
+                    "type": "video",
+                    "sources": [
+                      { "url": "https://static.pocketcasts.com/whats-new/media/retry-download.mp4", "mimeType": "video/mp4" }
+                    ],
+                    "posterUrl": "https://static.pocketcasts.com/whats-new/media/retry-download-poster.webp",
+                    "captionsUrl": "https://static.pocketcasts.com/whats-new/media/retry-download.vtt",
+                    "alt": "Swiping an episode to start its download again"
+                  },
+                  { "type": "heading", "level": 2, "text": "We're on it" },
+                  { "type": "paragraph", "content": "Some downloads stop short on a cellular connection. Swipe the episode and download it again while we work on a fix." }
                 ]
               }
             ]

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog+Mock.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog+Mock.swift
@@ -43,6 +43,10 @@ public extension WhatsNewCatalog {
     /// message carries a `poll` block the app doesn't model, so anything rendering the mock exercises
     /// a page that drops a block and still has something left to show. The release notes message is
     /// taller than any screen, so a page that has to scroll is covered too.
+    ///
+    /// The media points at assets that are actually there — podcast artwork and Apple's public
+    /// sample stream — so previews render something rather than a hole the size of the image. Only
+    /// the captions sidecar is made up, since there's no public one to point at.
     private static let mockMessages = [
         """
         {
@@ -139,7 +143,7 @@ public extension WhatsNewCatalog {
           "summary": {
             "title": "Introducing episode transcripts",
             "label": "New Feature",
-            "imageUrl": "https://static.pocketcasts.com/whats-new/media/transcripts-card.webp"
+            "imageUrl": "https://static.pocketcasts.com/discover/images/420/3782b780-0bc5-012e-fb02-00163e1b201c.jpg"
           },
           "content": {
             "title": "Introducing episode transcripts",
@@ -150,9 +154,9 @@ public extension WhatsNewCatalog {
                   { "type": "paragraph", "content": "Search a transcript and follow the conversation." },
                   {
                     "type": "image",
-                    "url": "https://static.pocketcasts.com/whats-new/media/transcripts-detail.webp",
-                    "width": 1200,
-                    "height": 750,
+                    "url": "https://static.pocketcasts.com/discover/images/420/82e37e80-755d-0138-eddc-0acc26574db2.jpg",
+                    "width": 420,
+                    "height": 420,
                     "alt": "Episode transcript open beside the player"
                   }
                 ]
@@ -181,9 +185,9 @@ public extension WhatsNewCatalog {
                   {
                     "type": "video",
                     "sources": [
-                      { "url": "https://static.pocketcasts.com/whats-new/media/retry-download.mp4", "mimeType": "video/mp4" }
+                      { "url": "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8", "mimeType": "application/x-mpegURL" }
                     ],
-                    "posterUrl": "https://static.pocketcasts.com/whats-new/media/retry-download-poster.webp",
+                    "posterUrl": "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg",
                     "captionsUrl": "https://static.pocketcasts.com/whats-new/media/retry-download.vtt",
                     "alt": "Swiping an episode to start its download again"
                   },
@@ -214,9 +218,9 @@ public extension WhatsNewCatalog {
                   { "type": "paragraph", "content": "Automatic downloads start as soon as an episode is released rather than waiting for the next refresh, and a download that fails is retried once on its own before it asks you to try again." },
                   {
                     "type": "image",
-                    "url": "https://static.pocketcasts.com/whats-new/media/downloads-detail.webp",
-                    "width": 1200,
-                    "height": 750,
+                    "url": "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg",
+                    "width": 420,
+                    "height": 420,
                     "alt": "The downloads screen with an episode part way through"
                   },
                   { "type": "heading", "level": 2, "text": "Sync" },

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog+Mock.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalog+Mock.swift
@@ -5,7 +5,7 @@ public extension WhatsNewCatalog {
     ///
     /// The messages are published relative to now rather than on fixed dates, so the feed keeps
     /// rendering the same spread of relative dates however long after this was written it's read.
-    static let mock = mock(publishedDaysAgo: [0, 8, 27, 36, 62, 90])
+    static let mock = mock(publishedDaysAgo: [0, 8, 27, 36, 62, 90, 118])
 
     /// A catalog whose messages were published the given number of days ago, most recent first.
     ///
@@ -41,7 +41,8 @@ public extension WhatsNewCatalog {
     ///
     /// Between them they cover every message type and every block the app renders. The user research
     /// message carries a `poll` block the app doesn't model, so anything rendering the mock exercises
-    /// a page that drops a block and still has something left to show.
+    /// a page that drops a block and still has something left to show. The release notes message is
+    /// taller than any screen, so a page that has to scroll is covered too.
     private static let mockMessages = [
         """
         {
@@ -188,6 +189,43 @@ public extension WhatsNewCatalog {
                   },
                   { "type": "heading", "level": 2, "text": "We're on it" },
                   { "type": "paragraph", "content": "Some downloads stop short on a cellular connection. Swipe the episode and download it again while we work on a fix." }
+                ]
+              }
+            ]
+          }
+        }
+        """,
+        """
+        {
+          "id": "01K2Y5R3TZ9B4D6MHXKQ0PWNC7",
+          "type": "announcement",
+          "publishedAt": "$publishedAt",
+          "targeting": { "audiences": [] },
+          "summary": { "title": "Everything new this month", "label": "Announcement" },
+          "content": {
+            "title": "Everything new this month",
+            "pages": [
+              {
+                "blocks": [
+                  { "type": "heading", "level": 2, "text": "Playback" },
+                  { "type": "paragraph", "content": "Playback speed is now per podcast as well as per episode, so a show you always listen to at 1.5x stays there without you setting it again each time." },
+                  { "type": "paragraph", "content": "Skipping forward and back keeps its place when you change episodes mid-chapter, and the sleep timer can now be extended from the lock screen." },
+                  { "type": "heading", "level": 2, "text": "Downloads" },
+                  { "type": "paragraph", "content": "Automatic downloads start as soon as an episode is released rather than waiting for the next refresh, and a download that fails is retried once on its own before it asks you to try again." },
+                  {
+                    "type": "image",
+                    "url": "https://static.pocketcasts.com/whats-new/media/downloads-detail.webp",
+                    "width": 1200,
+                    "height": 750,
+                    "alt": "The downloads screen with an episode part way through"
+                  },
+                  { "type": "heading", "level": 2, "text": "Sync" },
+                  { "type": "paragraph", "content": "Up Next syncs faster between devices, and a queue you reorder offline no longer loses that order when you come back online." },
+                  { "type": "paragraph", "content": "Folders sync on their own schedule instead of waiting for a full refresh, so a folder you make on the web shows up on your phone within a minute or so." },
+                  { "type": "heading", "level": 2, "text": "Fixes" },
+                  { "type": "paragraph", "content": "We fixed the artwork that stayed blank after a podcast changed its feed, the filter that counted archived episodes, and a crash when a chapter had no title." },
+                  { "type": "paragraph", "content": "Thanks to everyone who wrote in about these — most of them were reported by people using the app every day." },
+                  { "type": "action", "label": "Read the full release notes", "url": "https://blog.pocketcasts.com", "style": "primary" }
                 ]
               }
             ]

--- a/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
@@ -43,6 +43,42 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.hasUnreadItems)
     }
 
+    /// Everything on a message's only page can be dropped — an action the allowlist won't open is
+    /// the app's own doing — which would leave a row that opens onto nothing.
+    func testMessagesWithNothingToShowNeverReachTheFeed() throws {
+        let messages = try decodedMessages(json: """
+        {
+          "schemaVersion": 1,
+          "messages": [
+            {
+              "id": "01K2Y08DAWG9N7XJZX5QTH9Z0K",
+              "type": "tip",
+              "publishedAt": "2026-08-17T08:00:00Z",
+              "targeting": { "audiences": [] },
+              "summary": { "title": "Sort your Up Next" },
+              "content": { "pages": [{ "blocks": [{ "type": "paragraph", "content": "…" }] }] }
+            },
+            {
+              "id": "01K2Y3D5J1H7QZP0B6RXKA4N3T",
+              "type": "tip",
+              "publishedAt": "2026-08-18T08:00:00Z",
+              "targeting": { "audiences": [] },
+              "summary": { "title": "Rate us" },
+              "content": {
+                "pages": [
+                  { "blocks": [{ "type": "action", "label": "Rate us", "url": "itms-apps://apps.apple.com/app/id414834813" }] }
+                ]
+              }
+            }
+          ]
+        }
+        """)
+
+        let viewModel = WhatsNewFeedViewModel(messages: messages)
+
+        XCTAssertEqual(viewModel.items.map(\.title), ["Sort your Up Next"])
+    }
+
     func testReadingEverythingClearsEveryIndicator() {
         let viewModel = WhatsNewFeedViewModel(messages: messages)
         XCTAssertTrue(viewModel.hasUnreadItems)
@@ -50,5 +86,14 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
         viewModel.markAllAsRead()
 
         XCTAssertFalse(viewModel.hasUnreadItems)
+    }
+
+    // MARK: - Helpers
+
+    private func decodedMessages(json: String) throws -> [WhatsNewMessage] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        return try decoder.decode(WhatsNewCatalog.self, from: Data(json.utf8)).messages
     }
 }

--- a/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
@@ -1,0 +1,54 @@
+import PocketCastsServer
+import XCTest
+
+@testable import podcasts
+
+@MainActor
+final class WhatsNewFeedViewModelTests: XCTestCase {
+    private let messages = WhatsNewCatalog.mock.messages
+
+    func testItemsAreMostRecentlyPublishedFirst() {
+        let viewModel = WhatsNewFeedViewModel(messages: messages.shuffled())
+
+        XCTAssertEqual(viewModel.items.map(\.publishedAt), messages.map(\.publishedAt).sorted(by: >))
+    }
+
+    /// The detail screen needs the whole message, not just what the row happened to show.
+    func testSelectingARowHandsOverItsMessage() throws {
+        let viewModel = WhatsNewFeedViewModel(messages: messages)
+        var selected: WhatsNewMessage?
+        viewModel.onSelect = { selected = $0 }
+
+        let item = try XCTUnwrap(viewModel.items.last)
+        viewModel.select(item)
+
+        XCTAssertEqual(selected?.id, item.id)
+    }
+
+    /// Opening the detail is what marks a message read.
+    func testSelectingARowMarksItRead() throws {
+        let viewModel = WhatsNewFeedViewModel(messages: messages)
+
+        let item = try XCTUnwrap(viewModel.items.first)
+        XCTAssertTrue(item.isUnread)
+
+        viewModel.select(item)
+
+        XCTAssertEqual(viewModel.items.first?.isUnread, false)
+    }
+
+    func testReadMessagesStartRead() {
+        let viewModel = WhatsNewFeedViewModel(messages: messages, readMessageIDs: Set(messages.map(\.id)))
+
+        XCTAssertFalse(viewModel.hasUnreadItems)
+    }
+
+    func testReadingEverythingClearsEveryIndicator() {
+        let viewModel = WhatsNewFeedViewModel(messages: messages)
+        XCTAssertTrue(viewModel.hasUnreadItems)
+
+        viewModel.markAllAsRead()
+
+        XCTAssertFalse(viewModel.hasUnreadItems)
+    }
+}

--- a/PocketCastsTests/Tests/Whats New/WhatsNewLinkTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewLinkTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import podcasts
+
+final class WhatsNewLinkTests: XCTestCase {
+    func testAppSchemeIsADeepLink() throws {
+        let url = try XCTUnwrap(URL(string: "pktc://playlists"))
+
+        XCTAssertEqual(WhatsNewLink(url: url), .deepLink(url))
+    }
+
+    /// The catalog is written once for every client, so the scheme the contract publishes has to
+    /// resolve to the one this app registers.
+    func testContractSchemeIsRewrittenToTheAppScheme() throws {
+        let url = try XCTUnwrap(URL(string: "pocketcasts://upnext?source=whats_new"))
+        let expected = try XCTUnwrap(URL(string: "pktc://upnext?source=whats_new"))
+
+        XCTAssertEqual(WhatsNewLink(url: url), .deepLink(expected))
+    }
+
+    func testSchemeMatchingIgnoresCase() throws {
+        let url = try XCTUnwrap(URL(string: "PKTC://playlists"))
+
+        XCTAssertEqual(WhatsNewLink(url: url), .deepLink(url))
+    }
+
+    func testHTTPSIsAWebLink() throws {
+        let url = try XCTUnwrap(URL(string: "https://blog.pocketcasts.com/whats-new"))
+
+        XCTAssertEqual(WhatsNewLink(url: url), .web(url))
+    }
+
+    /// Everything else is dropped rather than handed to the system: the catalog is public and
+    /// declarative, not a way to ask the app to open whatever a URL points at.
+    func testEverythingElseIsRejected() throws {
+        let urls = [
+            "http://blog.pocketcasts.com",
+            "mailto:support@pocketcasts.com",
+            "tel:5551234",
+            "itms-apps://apps.apple.com/app/id414834813",
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "some-other-app://open"
+        ]
+
+        for string in urls {
+            let url = try XCTUnwrap(URL(string: string))
+            XCTAssertNil(WhatsNewLink(url: url), "\(string) should not resolve to a link")
+        }
+    }
+
+    func testAURLWithNoSchemeIsRejected() throws {
+        let url = try XCTUnwrap(URL(string: "pocketcasts.com/whats-new"))
+
+        XCTAssertNil(WhatsNewLink(url: url))
+    }
+}

--- a/PocketCastsTests/Tests/Whats New/WhatsNewMediaLayoutTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewMediaLayoutTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+@testable import podcasts
+
+final class WhatsNewMediaLayoutTests: XCTestCase {
+    private let page = CGSize(width: 362, height: 874)
+
+    func testALandscapeImageFillsTheWidth() {
+        let size = WhatsNewMediaLayout.size(aspectRatio: 1200 / 750, in: page)
+
+        XCTAssertEqual(size.width, page.width, accuracy: 0.5)
+        XCTAssertEqual(size.height, 226, accuracy: 0.5)
+    }
+
+    /// A phone screenshot at full width would push everything under it off the page.
+    func testAPortraitImageIsHeldToTheHeightTheDesignGivesIt() {
+        let size = WhatsNewMediaLayout.size(aspectRatio: 222 / 451, in: page)
+
+        XCTAssertLessThan(size.width, page.width)
+        XCTAssertEqual(size.height, page.height * 0.52, accuracy: 0.5)
+    }
+
+    func testTheAspectRatioIsKept() {
+        for aspectRatio in [0.4, 0.75, 1, 1.6, 2.4] as [CGFloat] {
+            let size = WhatsNewMediaLayout.size(aspectRatio: aspectRatio, in: page)
+
+            XCTAssertEqual(size.width / size.height, aspectRatio, accuracy: 0.01)
+        }
+    }
+}

--- a/PocketCastsTests/Tests/Whats New/WhatsNewMessageViewModelTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewMessageViewModelTests.swift
@@ -1,0 +1,111 @@
+import PocketCastsServer
+import XCTest
+
+@testable import podcasts
+
+final class WhatsNewMessageViewModelTests: XCTestCase {
+    func testTitleComesFromTheContent() throws {
+        let viewModel = WhatsNewMessageViewModel(message: try message(content: """
+        { "title": "Read along while you listen", "pages": [{ "blocks": [{ "type": "paragraph", "content": "…" }] }] }
+        """))
+
+        XCTAssertEqual(viewModel.title, "Read along while you listen")
+    }
+
+    /// Not every message titles its content, and the feed row's title is what the reader tapped.
+    func testTitleFallsBackToTheSummary() throws {
+        let viewModel = WhatsNewMessageViewModel(message: try message(content: """
+        { "pages": [{ "blocks": [{ "type": "paragraph", "content": "…" }] }] }
+        """))
+
+        XCTAssertEqual(viewModel.title, "Introducing episode transcripts")
+    }
+
+    func testPagesKeepTheirPublishedOrder() throws {
+        let viewModel = WhatsNewMessageViewModel(message: try message(content: """
+        {
+          "pages": [
+            { "blocks": [{ "type": "heading", "level": 2, "text": "First" }] },
+            { "blocks": [{ "type": "heading", "level": 2, "text": "Second" }] }
+          ]
+        }
+        """))
+
+        XCTAssertEqual(viewModel.pages.map(\.id), [0, 1])
+        XCTAssertEqual(viewModel.pages.compactMap { $0.blocks.first?.headingText }, ["First", "Second"])
+    }
+
+    /// An action the allowlist won't open would draw a button that does nothing, so it never
+    /// reaches the screen.
+    func testActionsPointingSomewhereUnsupportedAreDropped() throws {
+        let viewModel = WhatsNewMessageViewModel(message: try message(content: """
+        {
+          "pages": [
+            {
+              "blocks": [
+                { "type": "paragraph", "content": "…" },
+                { "type": "action", "label": "Rate us", "url": "itms-apps://apps.apple.com/app/id414834813" },
+                { "type": "action", "label": "Try transcripts", "url": "pocketcasts://podcasts" }
+              ]
+            }
+          ]
+        }
+        """))
+
+        XCTAssertEqual(viewModel.pages.first?.blocks.count, 2)
+        XCTAssertEqual(viewModel.pages.first?.blocks.compactMap { $0.actionLabel }, ["Try transcripts"])
+    }
+
+    /// Dropping the only block on a page would leave an empty one to swipe through.
+    func testAPageLeftWithNothingToShowIsDropped() throws {
+        let viewModel = WhatsNewMessageViewModel(message: try message(content: """
+        {
+          "pages": [
+            { "blocks": [{ "type": "paragraph", "content": "…" }] },
+            { "blocks": [{ "type": "action", "label": "Rate us", "url": "itms-apps://apps.apple.com/app/id414834813" }] }
+          ]
+        }
+        """))
+
+        XCTAssertEqual(viewModel.pages.count, 1)
+        XCTAssertEqual(viewModel.pages.map(\.id), [0])
+    }
+
+    // MARK: - Helpers
+
+    /// A message whose summary is fixed and whose content is whatever the test is about.
+    private func message(content: String) throws -> WhatsNewMessage {
+        let json = """
+        {
+          "schemaVersion": 1,
+          "messages": [
+            {
+              "id": "01K2Y08DAWG9N7XJZX5QTH9Z0K",
+              "type": "new_feature",
+              "publishedAt": "2026-08-17T08:00:00Z",
+              "targeting": { "audiences": [] },
+              "summary": { "title": "Introducing episode transcripts" },
+              "content": \(content)
+            }
+          ]
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let catalog = try decoder.decode(WhatsNewCatalog.self, from: Data(json.utf8))
+        return try XCTUnwrap(catalog.messages.first)
+    }
+}
+
+private extension WhatsNewBlock {
+    var headingText: String? {
+        guard case .heading(let heading) = self else { return nil }
+        return heading.text
+    }
+
+    var actionLabel: String? {
+        guard case .action(let action) = self else { return nil }
+        return action.label
+    }
+}

--- a/PocketCastsTests/Tests/Whats New/WhatsNewMessageViewModelTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewMessageViewModelTests.swift
@@ -52,8 +52,29 @@ final class WhatsNewMessageViewModelTests: XCTestCase {
         }
         """))
 
-        XCTAssertEqual(viewModel.pages.first?.blocks.count, 2)
-        XCTAssertEqual(viewModel.pages.first?.blocks.compactMap { $0.actionLabel }, ["Try transcripts"])
+        XCTAssertEqual(viewModel.pages.first?.actions.map(\.label), ["Try transcripts"])
+    }
+
+    /// The buttons are pinned to the bottom of the page, so they're kept apart from the blocks that
+    /// scroll rather than drawn where the catalog happened to put them.
+    func testActionsAreKeptOutOfTheBlocksThatScroll() throws {
+        let viewModel = WhatsNewMessageViewModel(message: try message(content: """
+        {
+          "pages": [
+            {
+              "blocks": [
+                { "type": "action", "label": "Try transcripts", "url": "pocketcasts://podcasts" },
+                { "type": "paragraph", "content": "…" },
+                { "type": "action", "label": "Read more", "url": "https://blog.pocketcasts.com" }
+              ]
+            }
+          ]
+        }
+        """))
+
+        let page = try XCTUnwrap(viewModel.pages.first)
+        XCTAssertEqual(page.blocks.count, 1)
+        XCTAssertEqual(page.actions.map(\.label), ["Try transcripts", "Read more"])
     }
 
     /// Dropping the only block on a page would leave an empty one to swipe through.
@@ -102,10 +123,5 @@ private extension WhatsNewBlock {
     var headingText: String? {
         guard case .heading(let heading) = self else { return nil }
         return heading.text
-    }
-
-    var actionLabel: String? {
-        guard case .action(let action) = self else { return nil }
-        return action.label
     }
 }

--- a/PocketCastsTests/Tests/Whats New/WhatsNewVideoCaptionsTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewVideoCaptionsTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+@testable import podcasts
+
+final class WhatsNewVideoCaptionsTests: XCTestCase {
+    private let vtt = """
+    WEBVTT
+
+    1
+    00:00:00.000 --> 00:00:02.500
+    Open Up Next
+
+    2
+    00:00:03.000 --> 00:00:06.000
+    Then sort by release date
+    """
+
+    func testTextIsTheCueCoveringThatMoment() throws {
+        let captions = try XCTUnwrap(WhatsNewVideoCaptions(webVTT: vtt))
+
+        XCTAssertEqual(captions.text(at: 1), "Open Up Next")
+        XCTAssertEqual(captions.text(at: 4), "Then sort by release date")
+    }
+
+    func testThereIsNoTextBetweenCues() throws {
+        let captions = try XCTUnwrap(WhatsNewVideoCaptions(webVTT: vtt))
+
+        XCTAssertNil(captions.text(at: 2.75))
+        XCTAssertNil(captions.text(at: 30))
+    }
+
+    /// A player reports an indefinite time before it knows the duration.
+    func testAnIndefiniteTimeHasNoText() throws {
+        let captions = try XCTUnwrap(WhatsNewVideoCaptions(webVTT: vtt))
+
+        XCTAssertNil(captions.text(at: .nan))
+        XCTAssertNil(captions.text(at: .infinity))
+    }
+
+    func testCaptionsThatAreNotWebVTTAreIgnored() {
+        XCTAssertNil(WhatsNewVideoCaptions(webVTT: "<html><body>Not a caption file</body></html>"))
+        XCTAssertNil(WhatsNewVideoCaptions(webVTT: ""))
+    }
+
+    func testCaptionsThatAreNotTextAreIgnored() {
+        XCTAssertNil(WhatsNewVideoCaptions(data: Data([0xFF, 0xFE, 0xFD])))
+    }
+}

--- a/podcasts/Whats New/Feed/WhatsNewFeedViewController.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedViewController.swift
@@ -22,12 +22,20 @@ class WhatsNewFeedViewController: PCHostingController<WhatsNewFeedView> {
         title = L10n.whatsNew
         navigationItem.largeTitleDisplayMode = .never
 
+        viewModel.onSelect = { [weak self] message in
+            self?.show(message)
+        }
+
         viewModel.$items
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 self?.updateReadAllButton()
             }
             .store(in: &cancellables)
+    }
+
+    private func show(_ message: WhatsNewMessage) {
+        navigationController?.pushViewController(WhatsNewMessageViewController(message: message), animated: true)
     }
 
     private func updateReadAllButton() {

--- a/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
@@ -28,12 +28,13 @@ final class WhatsNewFeedViewModel: ObservableObject {
     @Published private(set) var items: [WhatsNewFeedItem]
 
     /// Called with the message a tapped row belongs to.
-    var onSelect: ((WhatsNewFeedItem) -> Void)?
+    var onSelect: ((WhatsNewMessage) -> Void)?
+
+    private let messages: [WhatsNewMessage]
 
     init(messages: [WhatsNewMessage], readMessageIDs: Set<String> = []) {
-        items = messages
-            .sorted { $0.publishedAt > $1.publishedAt }
-            .map { WhatsNewFeedItem(message: $0, isUnread: !readMessageIDs.contains($0.id)) }
+        self.messages = messages.sorted { $0.publishedAt > $1.publishedAt }
+        items = self.messages.map { WhatsNewFeedItem(message: $0, isUnread: !readMessageIDs.contains($0.id)) }
     }
 
     var hasUnreadItems: Bool {
@@ -42,7 +43,9 @@ final class WhatsNewFeedViewModel: ObservableObject {
 
     func select(_ item: WhatsNewFeedItem) {
         markAsRead(item.id)
-        onSelect?(item)
+
+        guard let message = messages.first(where: { $0.id == item.id }) else { return }
+        onSelect?(message)
     }
 
     func markAllAsRead() {

--- a/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
@@ -23,6 +23,9 @@ struct WhatsNewFeedItem: Identifiable, Hashable {
 }
 
 /// The messages the What's New feed shows, most recently published first.
+///
+/// A message this build has nothing to draw never reaches the list, so no row opens onto an empty
+/// screen — or marks itself read on the way there.
 @MainActor
 final class WhatsNewFeedViewModel: ObservableObject {
     @Published private(set) var items: [WhatsNewFeedItem]
@@ -33,7 +36,9 @@ final class WhatsNewFeedViewModel: ObservableObject {
     private let messages: [WhatsNewMessage]
 
     init(messages: [WhatsNewMessage], readMessageIDs: Set<String> = []) {
-        self.messages = messages.sorted { $0.publishedAt > $1.publishedAt }
+        self.messages = messages
+            .filter(WhatsNewMessageViewModel.canRender)
+            .sorted { $0.publishedAt > $1.publishedAt }
         items = self.messages.map { WhatsNewFeedItem(message: $0, isUnread: !readMessageIDs.contains($0.id)) }
     }
 

--- a/podcasts/Whats New/Message/WhatsNewBlockView.swift
+++ b/podcasts/Whats New/Message/WhatsNewBlockView.swift
@@ -1,0 +1,154 @@
+import PocketCastsServer
+import SwiftUI
+
+/// One block of a What's New page, drawn the way its type calls for.
+struct WhatsNewBlockView: View {
+    let block: WhatsNewBlock
+
+    /// The space the page has for its content, which media sizes itself against.
+    let contentSize: CGSize
+
+    /// Whether the page this block is on is the one on screen, so a video only plays in view.
+    let isVisible: Bool
+
+    var body: some View {
+        switch block {
+        case .heading(let heading):
+            WhatsNewHeadingView(heading: heading)
+        case .paragraph(let paragraph):
+            WhatsNewParagraphView(paragraph: paragraph)
+        case .image(let image):
+            WhatsNewImageView(image: image, contentSize: contentSize)
+        case .video(let video):
+            WhatsNewVideoView(video: video, contentSize: contentSize, isVisible: isVisible)
+        case .action(let action):
+            WhatsNewActionView(action: action)
+        }
+    }
+}
+
+/// How big a What's New image or video draws on a page.
+enum WhatsNewMediaLayout {
+    /// The share of a page the design gives its screenshot, which leaves room for the text beneath.
+    private static let heightFraction: CGFloat = 0.52
+
+    /// As wide as the page allows, but never so tall that it pushes what follows it off the page.
+    static func size(aspectRatio: CGFloat, in contentSize: CGSize) -> CGSize {
+        let height = min(contentSize.height * heightFraction, contentSize.width / aspectRatio)
+        return CGSize(width: height * aspectRatio, height: height)
+    }
+}
+
+// MARK: - Text
+
+private struct WhatsNewHeadingView: View {
+    @EnvironmentObject private var theme: Theme
+
+    let heading: WhatsNewHeading
+
+    var body: some View {
+        Text(heading.text)
+            .font(size: fontSize, style: textStyle, weight: .semibold)
+            .foregroundStyle(theme.primaryText01)
+            .multilineTextAlignment(.leading)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    private var fontSize: Double {
+        heading.level <= 1 ? 22 : 17
+    }
+
+    private var textStyle: Font.TextStyle {
+        heading.level <= 1 ? .title3 : .headline
+    }
+}
+
+private struct WhatsNewParagraphView: View {
+    @EnvironmentObject private var theme: Theme
+
+    let paragraph: WhatsNewParagraph
+
+    var body: some View {
+        Text(paragraph.content)
+            .font(size: 15, style: .subheadline)
+            .foregroundStyle(theme.primaryText01)
+            .multilineTextAlignment(.leading)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Image
+
+/// An image block, sized from the dimensions the catalog published so the page doesn't reflow
+/// around it once it loads.
+private struct WhatsNewImageView: View {
+    let image: WhatsNewImage
+    let contentSize: CGSize
+
+    var body: some View {
+        Group {
+            if let aspectRatio {
+                let size = WhatsNewMediaLayout.size(aspectRatio: aspectRatio, in: contentSize)
+
+                imageView(aspectRatio: aspectRatio)
+                    .frame(width: size.width, height: size.height)
+            } else {
+                imageView(aspectRatio: nil)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityHidden(image.alt == nil)
+        .accessibilityLabel(image.alt ?? "")
+        .accessibilityAddTraits(.isImage)
+    }
+
+    private func imageView(aspectRatio: CGFloat?) -> some View {
+        AsyncImageView(url: image.url,
+                       cache: ImageManager.sharedManager.discoverCache,
+                       aspectRatio: aspectRatio,
+                       contentMode: .fit)
+    }
+
+    /// The shape the catalog published, or `nil` when it published no dimensions and the image has
+    /// to size itself once it arrives.
+    private var aspectRatio: CGFloat? {
+        guard let width = image.width, let height = image.height, width > 0, height > 0 else { return nil }
+        return CGFloat(width) / CGFloat(height)
+    }
+}
+
+// MARK: - Action
+
+/// A call to action, which opens an in-app destination or a web page.
+///
+/// A URL the app has no way to open isn't drawn at all: whether the action succeeds or fails has
+/// nothing to do with the message being read, so there's nothing to report back either way.
+private struct WhatsNewActionView: View {
+    @EnvironmentObject private var theme: Theme
+
+    let action: WhatsNewAction
+
+    var body: some View {
+        if let link = WhatsNewLink(url: action.url) {
+            switch action.style {
+            case .primary:
+                button(opening: link)
+                    .buttonStyle(RoundedButtonStyle(theme: theme))
+            case .secondary:
+                button(opening: link)
+                    .buttonStyle(StrokeButton(textColor: theme.primaryInteractive01,
+                                              backgroundColor: .clear,
+                                              strokeColor: theme.primaryInteractive01))
+            }
+        }
+    }
+
+    private func button(opening link: WhatsNewLink) -> some View {
+        Button(action.label) {
+            link.open()
+        }
+    }
+}

--- a/podcasts/Whats New/Message/WhatsNewBlockView.swift
+++ b/podcasts/Whats New/Message/WhatsNewBlockView.swift
@@ -126,7 +126,7 @@ private struct WhatsNewImageView: View {
 ///
 /// A URL the app has no way to open isn't drawn at all: whether the action succeeds or fails has
 /// nothing to do with the message being read, so there's nothing to report back either way.
-private struct WhatsNewActionView: View {
+struct WhatsNewActionView: View {
     @EnvironmentObject private var theme: Theme
 
     let action: WhatsNewAction

--- a/podcasts/Whats New/Message/WhatsNewLink.swift
+++ b/podcasts/Whats New/Message/WhatsNewLink.swift
@@ -1,0 +1,58 @@
+import Foundation
+import JLRoutes
+import UIKit
+
+/// Somewhere a What's New action block is allowed to send the user.
+///
+/// The catalog is public, declarative content rather than a format the app executes, so an action's
+/// URL has to resolve to one of the two kinds of link the app implements. Anything else — another
+/// app's scheme, a plain `http` page, a `mailto:` — is dropped instead of handed to the system.
+enum WhatsNewLink: Hashable {
+    /// A destination inside the app, routed the same way as any other Pocket Casts deep link.
+    case deepLink(URL)
+
+    /// A web page, opened in an in-app Safari view.
+    case web(URL)
+
+    /// The scheme the app registers.
+    private static let appScheme = "pktc"
+
+    /// The scheme the shared What's New contract writes in-app links with.
+    ///
+    /// The catalog is authored once for every client, so iOS answers to it as well as to its own.
+    private static let contractScheme = "pocketcasts"
+
+    init?(url: URL) {
+        guard let scheme = url.scheme?.lowercased() else { return nil }
+
+        switch scheme {
+        case Self.appScheme:
+            self = .deepLink(url)
+        case Self.contractScheme:
+            guard let url = url.replacingScheme(with: Self.appScheme) else { return nil }
+            self = .deepLink(url)
+        case "https":
+            self = .web(url)
+        default:
+            return nil
+        }
+    }
+
+    @MainActor
+    func open() {
+        switch self {
+        case .deepLink(let url):
+            JLRoutes.routeURL(url)
+        case .web(let url):
+            UIApplication.shared.openSafariVCIfPossible(url)
+        }
+    }
+}
+
+private extension URL {
+    func replacingScheme(with scheme: String) -> URL? {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return nil }
+        components.scheme = scheme
+        return components.url
+    }
+}

--- a/podcasts/Whats New/Message/WhatsNewMessageView.swift
+++ b/podcasts/Whats New/Message/WhatsNewMessageView.swift
@@ -28,7 +28,7 @@ struct WhatsNewMessageView: View {
 }
 
 /// A single page, which scrolls when its blocks are taller than the space they're given rather than
-/// clipping them.
+/// clipping them, and keeps its calls to action pinned beneath them.
 private struct WhatsNewMessagePageView: View {
     /// The gutter the design leaves either side of a page's content.
     private let horizontalPadding: CGFloat = 20
@@ -40,17 +40,36 @@ private struct WhatsNewMessagePageView: View {
         GeometryReader { proxy in
             let contentSize = CGSize(width: proxy.size.width - horizontalPadding * 2, height: proxy.size.height)
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(page.blocks.enumerated()), id: \.offset) { index, block in
-                        WhatsNewBlockView(block: block, contentSize: contentSize, isVisible: isVisible)
-                            .padding(.top, topPadding(forBlockAt: index))
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(Array(page.blocks.enumerated()), id: \.offset) { index, block in
+                            WhatsNewBlockView(block: block, contentSize: contentSize, isVisible: isVisible)
+                                .padding(.top, topPadding(forBlockAt: index))
+                        }
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, horizontalPadding)
+                    .padding(.bottom, 24)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, horizontalPadding)
-                .padding(.bottom, 24)
+
+                actions
             }
+        }
+    }
+
+    /// The page's calls to action, kept where they can be reached however far the content scrolls.
+    @ViewBuilder
+    private var actions: some View {
+        if !page.actions.isEmpty {
+            VStack(spacing: 12) {
+                ForEach(Array(page.actions.enumerated()), id: \.offset) { _, action in
+                    WhatsNewActionView(action: action)
+                }
+            }
+            .padding(.horizontal, horizontalPadding)
+            .padding(.top, 16)
+            .padding(.bottom, 8)
         }
     }
 
@@ -65,8 +84,6 @@ private struct WhatsNewMessagePageView: View {
             return 40
         case (.heading, .paragraph):
             return 16
-        case (_, .action):
-            return 28
         default:
             return 20
         }

--- a/podcasts/Whats New/Message/WhatsNewMessageView.swift
+++ b/podcasts/Whats New/Message/WhatsNewMessageView.swift
@@ -102,6 +102,9 @@ private extension WhatsNewMessage {
     /// The mock catalog's single-page message, which shows no pagination controls.
     static var singlePageMock: WhatsNewMessage { mock(titled: "Sort your Up Next") }
 
+    /// The mock catalog's message whose blocks are taller than a page, so it has to scroll.
+    static var longPageMock: WhatsNewMessage { mock(titled: "Everything new this month") }
+
     /// The mock catalog's message built around a video demo.
     static var videoMock: WhatsNewMessage { mock(titled: "Downloads stalling on cellular") }
 
@@ -119,6 +122,10 @@ private extension WhatsNewMessage {
 
 #Preview("A single page") {
     PCNavigationController(rootViewController: WhatsNewMessageViewController(message: .singlePageMock))
+}
+
+#Preview("A long page") {
+    PCNavigationController(rootViewController: WhatsNewMessageViewController(message: .longPageMock))
 }
 
 #Preview("A video demo") {

--- a/podcasts/Whats New/Message/WhatsNewMessageView.swift
+++ b/podcasts/Whats New/Message/WhatsNewMessageView.swift
@@ -30,15 +30,10 @@ struct WhatsNewMessageView: View {
 /// A single page, which scrolls when its blocks are taller than the space they're given rather than
 /// clipping them, and keeps its calls to action pinned beneath them.
 private struct WhatsNewMessagePageView: View {
+    @EnvironmentObject private var theme: Theme
+
     /// The gutter the design leaves either side of a page's content.
     private let horizontalPadding: CGFloat = 20
-
-    /// The name the page's own geometry goes by, so the content and the actions can be measured
-    /// against each other.
-    private let coordinateSpace = "WhatsNewMessagePage"
-
-    @State private var contentBottom: CGFloat = 0
-    @State private var actionsTop: CGFloat = .greatestFiniteMagnitude
 
     let page: WhatsNewMessageViewModel.Page
     let isVisible: Bool
@@ -57,21 +52,12 @@ private struct WhatsNewMessagePageView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, horizontalPadding)
                 .padding(.bottom, 24)
-                .background {
-                    GeometryReader { content in
-                        Color.clear.preference(key: ContentBottomKey.self, value: content.frame(in: .named(coordinateSpace)).maxY)
-                    }
-                }
             }
             .safeAreaInset(edge: .bottom, spacing: 0) { actions }
-            .coordinateSpace(name: coordinateSpace)
-            .onPreferenceChange(ContentBottomKey.self) { contentBottom = $0 }
-            .onPreferenceChange(ActionsTopKey.self) { actionsTop = $0 }
         }
     }
 
-    /// The page's calls to action, which the content scrolls behind. They take on a bar of their own
-    /// while it is back there, the way a navigation bar does.
+    /// The page's calls to action, pinned beneath the content that scrolls behind them.
     @ViewBuilder
     private var actions: some View {
         if !page.actions.isEmpty {
@@ -83,28 +69,8 @@ private struct WhatsNewMessagePageView: View {
             .padding(.horizontal, horizontalPadding)
             .padding(.top, 16)
             .padding(.bottom, 8)
-            .background {
-                if isContentBehindActions {
-                    Rectangle().fill(.bar)
-                }
-            }
-            .overlay(alignment: .top) {
-                if isContentBehindActions {
-                    Divider()
-                }
-            }
-            .animation(.easeInOut(duration: 0.2), value: isContentBehindActions)
-            .background {
-                GeometryReader { actions in
-                    Color.clear.preference(key: ActionsTopKey.self, value: actions.frame(in: .named(coordinateSpace)).minY)
-                }
-            }
+            .background(theme.primaryUi01)
         }
-    }
-
-    /// Whether the content has scrolled in behind the actions, which is when they need an edge.
-    private var isContentBehindActions: Bool {
-        contentBottom > actionsTop + 1
     }
 
     /// The space the design leaves above a block, which depends on what it follows.
@@ -121,24 +87,6 @@ private struct WhatsNewMessagePageView: View {
         default:
             return 20
         }
-    }
-}
-
-/// How far down the page the scrolling content reaches.
-private struct ContentBottomKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
-}
-
-/// Where the page's actions begin.
-private struct ActionsTopKey: PreferenceKey {
-    static let defaultValue = CGFloat.greatestFiniteMagnitude
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = min(value, nextValue())
     }
 }
 

--- a/podcasts/Whats New/Message/WhatsNewMessageView.swift
+++ b/podcasts/Whats New/Message/WhatsNewMessageView.swift
@@ -1,0 +1,134 @@
+import PocketCastsServer
+import SwiftUI
+
+/// A What's New message: its pages side by side, swiped through horizontally.
+struct WhatsNewMessageView: View {
+    @EnvironmentObject private var theme: Theme
+    @State private var currentPage = 0
+
+    let viewModel: WhatsNewMessageViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TabView(selection: $currentPage) {
+                ForEach(viewModel.pages) { page in
+                    WhatsNewMessagePageView(page: page, isVisible: page.id == currentPage)
+                        .tag(page.id)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+
+            if viewModel.pages.count > 1 {
+                WhatsNewPageIndicator(numberOfPages: viewModel.pages.count, currentPage: currentPage)
+                    .padding(.vertical, 20)
+            }
+        }
+        .background(theme.primaryUi01.ignoresSafeArea())
+    }
+}
+
+/// A single page, which scrolls when its blocks are taller than the space they're given rather than
+/// clipping them.
+private struct WhatsNewMessagePageView: View {
+    /// The gutter the design leaves either side of a page's content.
+    private let horizontalPadding: CGFloat = 20
+
+    let page: WhatsNewMessageViewModel.Page
+    let isVisible: Bool
+
+    var body: some View {
+        GeometryReader { proxy in
+            let contentSize = CGSize(width: proxy.size.width - horizontalPadding * 2, height: proxy.size.height)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(page.blocks.enumerated()), id: \.offset) { index, block in
+                        WhatsNewBlockView(block: block, contentSize: contentSize, isVisible: isVisible)
+                            .padding(.top, topPadding(forBlockAt: index))
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, horizontalPadding)
+                .padding(.bottom, 24)
+            }
+        }
+    }
+
+    /// The space the design leaves above a block, which depends on what it follows.
+    private func topPadding(forBlockAt index: Int) -> CGFloat {
+        guard index > 0 else { return 32 }
+
+        switch (page.blocks[index - 1], page.blocks[index]) {
+        case (_, .image), (_, .video):
+            return 32
+        case (.image, _), (.video, _):
+            return 40
+        case (.heading, .paragraph):
+            return 16
+        case (_, .action):
+            return 28
+        default:
+            return 20
+        }
+    }
+}
+
+/// The dots under a message with more than one page.
+private struct WhatsNewPageIndicator: View {
+    @EnvironmentObject private var theme: Theme
+
+    let numberOfPages: Int
+    let currentPage: Int
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(0 ..< numberOfPages, id: \.self) { page in
+                Circle()
+                    .fill(page == currentPage ? theme.primaryUi05Selected : theme.primaryUi05)
+                    .frame(width: 8, height: 8)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(L10n.pageControlPageProgressFormat("\(currentPage + 1)", "\(numberOfPages)"))
+    }
+}
+
+// MARK: - Previews
+
+private extension WhatsNewMessage {
+    /// The mock catalog's message that pages through a screenshot and on to a call to action.
+    static var multiPageMock: WhatsNewMessage { mock(titled: "Introducing episode transcripts") }
+
+    /// The mock catalog's single-page message, which shows no pagination controls.
+    static var singlePageMock: WhatsNewMessage { mock(titled: "Sort your Up Next") }
+
+    /// The mock catalog's message built around a video demo.
+    static var videoMock: WhatsNewMessage { mock(titled: "Downloads stalling on cellular") }
+
+    /// The mock catalog's message whose call to action is the secondary style.
+    static var secondaryActionMock: WhatsNewMessage { mock(titled: "Ads to support Pocket Casts") }
+
+    private static func mock(titled title: String) -> WhatsNewMessage {
+        WhatsNewCatalog.mock.messages.first { $0.summary.title == title }!
+    }
+}
+
+#Preview("Multiple pages") {
+    PCNavigationController(rootViewController: WhatsNewMessageViewController(message: .multiPageMock))
+}
+
+#Preview("A single page") {
+    PCNavigationController(rootViewController: WhatsNewMessageViewController(message: .singlePageMock))
+}
+
+#Preview("A video demo") {
+    PCNavigationController(rootViewController: WhatsNewMessageViewController(message: .videoMock))
+}
+
+struct WhatsNewMessageView_Previews: PreviewProvider {
+    /// The secondary call to action is the one that has to hold up against every theme's background.
+    static var previews: some View {
+        WhatsNewMessageView(viewModel: WhatsNewMessageViewModel(message: .secondaryActionMock))
+            .previewWithAllThemes()
+    }
+}

--- a/podcasts/Whats New/Message/WhatsNewMessageView.swift
+++ b/podcasts/Whats New/Message/WhatsNewMessageView.swift
@@ -33,6 +33,13 @@ private struct WhatsNewMessagePageView: View {
     /// The gutter the design leaves either side of a page's content.
     private let horizontalPadding: CGFloat = 20
 
+    /// The name the page's own geometry goes by, so the content and the actions can be measured
+    /// against each other.
+    private let coordinateSpace = "WhatsNewMessagePage"
+
+    @State private var contentBottom: CGFloat = 0
+    @State private var actionsTop: CGFloat = .greatestFiniteMagnitude
+
     let page: WhatsNewMessageViewModel.Page
     let isVisible: Bool
 
@@ -40,25 +47,31 @@ private struct WhatsNewMessagePageView: View {
         GeometryReader { proxy in
             let contentSize = CGSize(width: proxy.size.width - horizontalPadding * 2, height: proxy.size.height)
 
-            VStack(spacing: 0) {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 0) {
-                        ForEach(Array(page.blocks.enumerated()), id: \.offset) { index, block in
-                            WhatsNewBlockView(block: block, contentSize: contentSize, isVisible: isVisible)
-                                .padding(.top, topPadding(forBlockAt: index))
-                        }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(page.blocks.enumerated()), id: \.offset) { index, block in
+                        WhatsNewBlockView(block: block, contentSize: contentSize, isVisible: isVisible)
+                            .padding(.top, topPadding(forBlockAt: index))
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, horizontalPadding)
-                    .padding(.bottom, 24)
                 }
-
-                actions
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, horizontalPadding)
+                .padding(.bottom, 24)
+                .background {
+                    GeometryReader { content in
+                        Color.clear.preference(key: ContentBottomKey.self, value: content.frame(in: .named(coordinateSpace)).maxY)
+                    }
+                }
             }
+            .safeAreaInset(edge: .bottom, spacing: 0) { actions }
+            .coordinateSpace(name: coordinateSpace)
+            .onPreferenceChange(ContentBottomKey.self) { contentBottom = $0 }
+            .onPreferenceChange(ActionsTopKey.self) { actionsTop = $0 }
         }
     }
 
-    /// The page's calls to action, kept where they can be reached however far the content scrolls.
+    /// The page's calls to action, which the content scrolls behind. They take on a bar of their own
+    /// while it is back there, the way a navigation bar does.
     @ViewBuilder
     private var actions: some View {
         if !page.actions.isEmpty {
@@ -70,7 +83,28 @@ private struct WhatsNewMessagePageView: View {
             .padding(.horizontal, horizontalPadding)
             .padding(.top, 16)
             .padding(.bottom, 8)
+            .background {
+                if isContentBehindActions {
+                    Rectangle().fill(.bar)
+                }
+            }
+            .overlay(alignment: .top) {
+                if isContentBehindActions {
+                    Divider()
+                }
+            }
+            .animation(.easeInOut(duration: 0.2), value: isContentBehindActions)
+            .background {
+                GeometryReader { actions in
+                    Color.clear.preference(key: ActionsTopKey.self, value: actions.frame(in: .named(coordinateSpace)).minY)
+                }
+            }
         }
+    }
+
+    /// Whether the content has scrolled in behind the actions, which is when they need an edge.
+    private var isContentBehindActions: Bool {
+        contentBottom > actionsTop + 1
     }
 
     /// The space the design leaves above a block, which depends on what it follows.
@@ -87,6 +121,24 @@ private struct WhatsNewMessagePageView: View {
         default:
             return 20
         }
+    }
+}
+
+/// How far down the page the scrolling content reaches.
+private struct ContentBottomKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+/// Where the page's actions begin.
+private struct ActionsTopKey: PreferenceKey {
+    static let defaultValue = CGFloat.greatestFiniteMagnitude
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = min(value, nextValue())
     }
 }
 

--- a/podcasts/Whats New/Message/WhatsNewMessageViewController.swift
+++ b/podcasts/Whats New/Message/WhatsNewMessageViewController.swift
@@ -1,0 +1,23 @@
+import PocketCastsServer
+import SwiftUI
+
+/// Hosts `WhatsNewMessageView` and owns the navigation bar the design puts around it.
+class WhatsNewMessageViewController: PCHostingController<WhatsNewMessageView> {
+    private let viewModel: WhatsNewMessageViewModel
+
+    init(message: WhatsNewMessage) {
+        viewModel = WhatsNewMessageViewModel(message: message)
+        super.init(rootView: WhatsNewMessageView(viewModel: viewModel), background: \.primaryUi01)
+    }
+
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = viewModel.title
+        navigationItem.largeTitleDisplayMode = .never
+    }
+}

--- a/podcasts/Whats New/Message/WhatsNewMessageViewController.swift
+++ b/podcasts/Whats New/Message/WhatsNewMessageViewController.swift
@@ -1,7 +1,7 @@
 import PocketCastsServer
 import SwiftUI
 
-/// Hosts `WhatsNewMessageView` and owns the navigation bar the design puts around it.
+/// Hosts `WhatsNewMessageView` under the app's usual navigation bar.
 class WhatsNewMessageViewController: PCHostingController<WhatsNewMessageView> {
     private let viewModel: WhatsNewMessageViewModel
 
@@ -19,26 +19,5 @@ class WhatsNewMessageViewController: PCHostingController<WhatsNewMessageView> {
 
         title = viewModel.title
         navigationItem.largeTitleDisplayMode = .never
-        setupNavBar()
-    }
-
-    @objc override func themeDidChange() {
-        super.themeDidChange()
-        setupNavBar()
-    }
-
-    /// Puts a translucent bar over the message rather than the app's usual opaque one, so a page
-    /// scrolls up underneath it instead of stopping at its edge. Liquid Glass already does this.
-    private func setupNavBar() {
-        guard !LiquidGlass.isEnabled else { return }
-
-        let appearance = UINavigationBarAppearance()
-        appearance.configureWithDefaultBackground()
-        appearance.shadowColor = nil
-        appearance.titleTextAttributes = [.foregroundColor: AppTheme.navBarTitleColor()]
-
-        navigationItem.standardAppearance = appearance
-        navigationItem.compactAppearance = appearance
-        navigationItem.scrollEdgeAppearance = appearance
     }
 }

--- a/podcasts/Whats New/Message/WhatsNewMessageViewController.swift
+++ b/podcasts/Whats New/Message/WhatsNewMessageViewController.swift
@@ -19,5 +19,26 @@ class WhatsNewMessageViewController: PCHostingController<WhatsNewMessageView> {
 
         title = viewModel.title
         navigationItem.largeTitleDisplayMode = .never
+        setupNavBar()
+    }
+
+    @objc override func themeDidChange() {
+        super.themeDidChange()
+        setupNavBar()
+    }
+
+    /// Puts a translucent bar over the message rather than the app's usual opaque one, so a page
+    /// scrolls up underneath it instead of stopping at its edge. Liquid Glass already does this.
+    private func setupNavBar() {
+        guard !LiquidGlass.isEnabled else { return }
+
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithDefaultBackground()
+        appearance.shadowColor = nil
+        appearance.titleTextAttributes = [.foregroundColor: AppTheme.navBarTitleColor()]
+
+        navigationItem.standardAppearance = appearance
+        navigationItem.compactAppearance = appearance
+        navigationItem.scrollEdgeAppearance = appearance
     }
 }

--- a/podcasts/Whats New/Message/WhatsNewMessageViewModel.swift
+++ b/podcasts/Whats New/Message/WhatsNewMessageViewModel.swift
@@ -1,0 +1,39 @@
+import Foundation
+import PocketCastsServer
+import PocketCastsUtils
+
+/// One What's New message, reduced to what the detail screen can actually draw.
+struct WhatsNewMessageViewModel {
+    /// The message's own title, falling back to the one its feed row uses.
+    let title: String
+
+    /// The pages the pager shows, in the order the catalog published them.
+    let pages: [Page]
+
+    /// A page of a message and the blocks it's made of.
+    struct Page: Identifiable {
+        /// The page's position, which is all the contract gives a page to be identified by.
+        let id: Int
+        let blocks: [WhatsNewBlock]
+    }
+
+    init(message: WhatsNewMessage) {
+        title = message.content.title ?? message.summary.title
+        pages = message.content.pages
+            .map { $0.blocks.filter(Self.isSupported) }
+            .filter { !$0.isEmpty }
+            .enumerated()
+            .map { Page(id: $0.offset, blocks: $0.element) }
+    }
+
+    /// Whether the app can draw the block, which for an action means having somewhere to send the
+    /// user: an action the allowlist rejects would otherwise render as a button that does nothing.
+    private static func isSupported(_ block: WhatsNewBlock) -> Bool {
+        guard case .action(let action) = block else { return true }
+        guard WhatsNewLink(url: action.url) != nil else {
+            FileLog.shared.addMessage("What's New: dropping an action pointing at an unsupported URL: \(action.url.absoluteString)")
+            return false
+        }
+        return true
+    }
+}

--- a/podcasts/Whats New/Message/WhatsNewMessageViewModel.swift
+++ b/podcasts/Whats New/Message/WhatsNewMessageViewModel.swift
@@ -14,7 +14,13 @@ struct WhatsNewMessageViewModel {
     struct Page: Identifiable {
         /// The page's position, which is all the contract gives a page to be identified by.
         let id: Int
+
+        /// The blocks that scroll, in the order the catalog published them.
         let blocks: [WhatsNewBlock]
+
+        /// The page's calls to action, which sit at the bottom of the page rather than scrolling
+        /// away with the content they were published between.
+        let actions: [WhatsNewAction]
     }
 
     init(message: WhatsNewMessage) {
@@ -23,7 +29,7 @@ struct WhatsNewMessageViewModel {
             .map { $0.blocks.filter(Self.isSupported) }
             .filter { !$0.isEmpty }
             .enumerated()
-            .map { Page(id: $0.offset, blocks: $0.element) }
+            .map { Page(id: $0.offset, blocks: $0.element.filter { $0.action == nil }, actions: $0.element.compactMap(\.action)) }
     }
 
     /// Whether the app can draw the block, which for an action means having somewhere to send the
@@ -35,5 +41,12 @@ struct WhatsNewMessageViewModel {
             return false
         }
         return true
+    }
+}
+
+private extension WhatsNewBlock {
+    var action: WhatsNewAction? {
+        guard case .action(let action) = self else { return nil }
+        return action
     }
 }

--- a/podcasts/Whats New/Message/WhatsNewMessageViewModel.swift
+++ b/podcasts/Whats New/Message/WhatsNewMessageViewModel.swift
@@ -32,6 +32,15 @@ struct WhatsNewMessageViewModel {
             .map { Page(id: $0.offset, blocks: $0.element.filter { $0.action == nil }, actions: $0.element.compactMap(\.action)) }
     }
 
+    /// Whether the app has anything to draw for the message.
+    ///
+    /// A page whose blocks are all dropped is dropped with them, and a message left with no pages
+    /// would open onto an empty pager, so the feed leaves it out rather than showing a row that
+    /// goes nowhere.
+    static func canRender(_ message: WhatsNewMessage) -> Bool {
+        !WhatsNewMessageViewModel(message: message).pages.isEmpty
+    }
+
     /// Whether the app can draw the block, which for an action means having somewhere to send the
     /// user: an action the allowlist rejects would otherwise render as a button that does nothing.
     private static func isSupported(_ block: WhatsNewBlock) -> Bool {

--- a/podcasts/Whats New/Message/WhatsNewVideoCaptions.swift
+++ b/podcasts/Whats New/Message/WhatsNewVideoCaptions.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftSubtitles
+
+/// The captions published alongside a What's New video.
+struct WhatsNewVideoCaptions {
+    private let subtitles: Subtitles
+
+    /// The extension SwiftSubtitles picks its WebVTT parser from.
+    private static let format = "vtt"
+
+    init?(data: Data) {
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        self.init(webVTT: text)
+    }
+
+    init?(webVTT: String) {
+        guard let subtitles = try? Subtitles(content: webVTT, expectedExtension: Self.format), !subtitles.isEmpty else {
+            return nil
+        }
+        self.subtitles = subtitles
+    }
+
+    /// What's being said at that point in the video, if anything is.
+    func text(at seconds: TimeInterval) -> String? {
+        guard seconds.isFinite else { return nil }
+        return subtitles.firstCue(containing: seconds)?.text
+    }
+}

--- a/podcasts/Whats New/Message/WhatsNewVideoView.swift
+++ b/podcasts/Whats New/Message/WhatsNewVideoView.swift
@@ -253,8 +253,8 @@ private struct WhatsNewVideoLayerView: UIViewRepresentable {
 // MARK: - Previews
 
 private extension WhatsNewVideo {
-    /// A block pointing at Apple's public sample stream, so the preview has something that plays:
-    /// the mock catalog's media URLs are made up, like the rest of the fixture.
+    /// A block pointing at Apple's public sample stream, so the video can be previewed on its own
+    /// without going through a message.
     static var previewSample: WhatsNewVideo {
         let json = """
         {

--- a/podcasts/Whats New/Message/WhatsNewVideoView.swift
+++ b/podcasts/Whats New/Message/WhatsNewVideoView.swift
@@ -197,9 +197,10 @@ private final class WhatsNewVideoPlayer: ObservableObject {
         }
 
         // A video that can't be played leaves the poster up, with the play button back for a retry.
+        // The failed item goes with it, or the retry would find it still loaded and play nothing.
         statusObservation = item.observe(\.status) { [weak self] item, _ in
             guard item.status == .failed else { return }
-            Task { @MainActor in self?.stop() }
+            Task { @MainActor in self?.tearDown() }
         }
 
         Task { await loadAspectRatio() }

--- a/podcasts/Whats New/Message/WhatsNewVideoView.swift
+++ b/podcasts/Whats New/Message/WhatsNewVideoView.swift
@@ -1,0 +1,280 @@
+import AVFoundation
+import PocketCastsServer
+import SwiftUI
+import UIKit
+
+/// A short demo video, muted and looping, over the poster the catalog published.
+///
+/// The poster sits under the video layer, which draws nothing until a frame is ready, so a video
+/// that hasn't started — or that never loads — leaves the poster on screen.
+struct WhatsNewVideoView: View {
+    @EnvironmentObject private var theme: Theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @StateObject private var player: WhatsNewVideoPlayer
+
+    let video: WhatsNewVideo
+    let contentSize: CGSize
+
+    /// Whether the page the video is on is the one on screen, so it stops when it's swiped away.
+    let isVisible: Bool
+
+    init(video: WhatsNewVideo, contentSize: CGSize, isVisible: Bool) {
+        self.video = video
+        self.contentSize = contentSize
+        self.isVisible = isVisible
+        _player = StateObject(wrappedValue: WhatsNewVideoPlayer(video: video))
+    }
+
+    var body: some View {
+        let size = WhatsNewMediaLayout.size(aspectRatio: player.aspectRatio, in: contentSize)
+
+        Button {
+            player.toggle()
+        } label: {
+            ZStack {
+                poster
+                WhatsNewVideoLayerView(player: player.player)
+                caption
+                playIndicator
+            }
+            .frame(width: size.width, height: size.height)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+        .frame(maxWidth: .infinity)
+        .accessibilityLabel(video.alt ?? L10n.whatsNewMessageVideo)
+        .accessibilityAddTraits(.startsMediaSession)
+        .onAppear { updatePlayback() }
+        .onDisappear { player.tearDown() }
+        .onChange(of: isVisible) { _, _ in updatePlayback() }
+    }
+
+    @ViewBuilder
+    private var poster: some View {
+        theme.primaryUi05
+
+        if let posterUrl = video.posterUrl {
+            // The poster keeps its own shape and fills the frame the video will play in.
+            AsyncImageView(url: posterUrl,
+                           cache: ImageManager.sharedManager.discoverCache,
+                           aspectRatio: nil,
+                           contentMode: .fill)
+        }
+    }
+
+    /// What's being said right now, when the catalog published captions to say it with.
+    @ViewBuilder
+    private var caption: some View {
+        if let caption = player.caption {
+            VStack {
+                Spacer(minLength: 0)
+
+                Text(caption)
+                    .font(size: 13, style: .footnote)
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(.black.opacity(0.7), in: RoundedRectangle(cornerRadius: 4))
+                    .padding(8)
+            }
+        }
+    }
+
+    /// Shown while the video is stopped, both as a hint that it plays and as something to aim at.
+    @ViewBuilder
+    private var playIndicator: some View {
+        if !player.isPlaying {
+            Image(systemName: "play.circle.fill")
+                .font(.system(size: 44))
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.white, .black.opacity(0.4))
+        }
+    }
+
+    /// Plays the video while it's on screen, unless the user has asked the system to hold back on
+    /// movement or is saving battery, in which case the poster waits for a tap instead.
+    private func updatePlayback() {
+        guard isVisible else {
+            player.stop()
+            return
+        }
+        guard !reduceMotion, !ProcessInfo.processInfo.isLowPowerModeEnabled else { return }
+        player.play()
+    }
+}
+
+/// Drives the `AVPlayer` behind a video block.
+@MainActor
+private final class WhatsNewVideoPlayer: ObservableObject {
+    @Published private(set) var isPlaying = false
+    @Published private(set) var caption: String?
+
+    /// The video's shape, which starts at the widescreen these demos are recorded in and settles on
+    /// whatever the asset turns out to be.
+    @Published private(set) var aspectRatio: CGFloat = 16 / 9
+
+    let player = AVPlayer()
+
+    private let video: WhatsNewVideo
+    private var captions: WhatsNewVideoCaptions?
+    private var timeObserver: Any?
+    private var endObserver: Any?
+    private var statusObservation: NSKeyValueObservation?
+
+    init(video: WhatsNewVideo) {
+        self.video = video
+
+        // The app is usually playing a podcast, and a demo has nothing to say over the top of it.
+        player.isMuted = true
+        player.allowsExternalPlayback = false
+        player.preventsDisplaySleepDuringVideoPlayback = false
+    }
+
+    func play() {
+        prepareIfNeeded()
+        guard player.currentItem != nil else { return }
+
+        player.play()
+        isPlaying = true
+    }
+
+    func stop() {
+        player.pause()
+        isPlaying = false
+    }
+
+    func toggle() {
+        isPlaying ? stop() : play()
+    }
+
+    /// Puts the player back to how it started, so nothing is left loaded behind a page the reader
+    /// has moved on from. Playing again loads it back.
+    func tearDown() {
+        stop()
+
+        if let timeObserver {
+            player.removeTimeObserver(timeObserver)
+        }
+        if let endObserver {
+            NotificationCenter.default.removeObserver(endObserver)
+        }
+        timeObserver = nil
+        endObserver = nil
+        statusObservation = nil
+        caption = nil
+        player.replaceCurrentItem(with: nil)
+    }
+
+    /// Loads the video the first time it's asked to play, so a page nobody swipes to fetches nothing.
+    private func prepareIfNeeded() {
+        guard player.currentItem == nil, let source = video.sources.first else { return }
+
+        let item = AVPlayerItem(url: source.url)
+        player.replaceCurrentItem(with: item)
+
+        endObserver = NotificationCenter.default.addObserver(forName: AVPlayerItem.didPlayToEndTimeNotification,
+                                                            object: item,
+                                                            queue: .main) { [weak self] _ in
+            MainActor.assumeIsolated { self?.replay() }
+        }
+
+        // A video that can't be played leaves the poster up, with the play button back for a retry.
+        statusObservation = item.observe(\.status) { [weak self] item, _ in
+            guard item.status == .failed else { return }
+            Task { @MainActor in self?.stop() }
+        }
+
+        Task { await loadAspectRatio() }
+
+        if let captionsUrl = video.captionsUrl {
+            Task { await loadCaptions(from: captionsUrl) }
+        }
+    }
+
+    private func replay() {
+        player.seek(to: .zero)
+        guard isPlaying else { return }
+        player.play()
+    }
+
+    private func loadAspectRatio() async {
+        guard let asset = player.currentItem?.asset,
+              let track = try? await asset.loadTracks(withMediaType: .video).first,
+              let size = try? await track.load(.naturalSize),
+              let transform = try? await track.load(.preferredTransform)
+        else { return }
+
+        let displayed = CGRect(origin: .zero, size: size).applying(transform)
+        guard displayed.width != 0, displayed.height != 0 else { return }
+
+        aspectRatio = abs(displayed.width / displayed.height)
+    }
+
+    private func loadCaptions(from url: URL) async {
+        guard let (data, _) = try? await URLSession.shared.data(from: url),
+              let captions = WhatsNewVideoCaptions(data: data)
+        else { return }
+
+        self.captions = captions
+        observeTime()
+    }
+
+    private func observeTime() {
+        guard timeObserver == nil else { return }
+
+        let interval = CMTime(seconds: 0.2, preferredTimescale: 600)
+        timeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] time in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.caption = self.captions?.text(at: time.seconds)
+            }
+        }
+    }
+}
+
+/// Draws an `AVPlayer` with no controls of its own, since tapping the block is what plays it.
+private struct WhatsNewVideoLayerView: UIViewRepresentable {
+    let player: AVPlayer
+
+    func makeUIView(context: Context) -> VideoPlayerView {
+        let view = VideoPlayerView()
+        view.backgroundColor = .clear
+        view.gravity = .resizeAspect
+        view.player = player
+        return view
+    }
+
+    func updateUIView(_ view: VideoPlayerView, context: Context) {
+        view.player = player
+    }
+}
+
+// MARK: - Previews
+
+private extension WhatsNewVideo {
+    /// A block pointing at Apple's public sample stream, so the preview has something that plays:
+    /// the mock catalog's media URLs are made up, like the rest of the fixture.
+    static var previewSample: WhatsNewVideo {
+        let json = """
+        {
+          "type": "video",
+          "sources": [
+            { "url": "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8", "mimeType": "application/x-mpegURL" }
+          ],
+          "alt": "A sample video"
+        }
+        """
+        return try! JSONDecoder().decode(WhatsNewVideo.self, from: Data(json.utf8))
+    }
+}
+
+#Preview("A video block") {
+    WhatsNewVideoView(video: .previewSample, contentSize: CGSize(width: 340, height: 600), isVisible: true)
+        .setupDefaultEnvironment()
+}
+
+#Preview("A video block, stopped") {
+    WhatsNewVideoView(video: .previewSample, contentSize: CGSize(width: 340, height: 600), isVisible: false)
+        .setupDefaultEnvironment()
+}

--- a/podcasts/Whats New/Message/WhatsNewVideoView.swift
+++ b/podcasts/Whats New/Message/WhatsNewVideoView.swift
@@ -130,11 +130,13 @@ private final class WhatsNewVideoPlayer: ObservableObject {
     private var endObserver: Any?
     private var statusObservation: NSKeyValueObservation?
     private var playbackObservation: NSKeyValueObservation?
+    private var preparation: Task<Void, Never>?
 
     init(video: WhatsNewVideo) {
         self.video = video
 
         // The app is usually playing a podcast, and a demo has nothing to say over the top of it.
+        // The audio is taken off the item as well, since muting alone still claims the session.
         player.isMuted = true
         player.allowsExternalPlayback = false
         player.preventsDisplaySleepDuringVideoPlayback = false
@@ -149,11 +151,13 @@ private final class WhatsNewVideoPlayer: ObservableObject {
     }
 
     func play() {
-        prepareIfNeeded()
-        guard player.currentItem != nil else { return }
-
         shouldPlay = true
-        player.play()
+
+        guard player.currentItem == nil else {
+            player.play()
+            return
+        }
+        prepare()
     }
 
     func stop() {
@@ -182,6 +186,8 @@ private final class WhatsNewVideoPlayer: ObservableObject {
         stop()
         removeObservers()
 
+        preparation?.cancel()
+        preparation = nil
         statusObservation = nil
         caption = nil
         player.replaceCurrentItem(with: nil)
@@ -199,12 +205,72 @@ private final class WhatsNewVideoPlayer: ObservableObject {
     }
 
     /// Loads the video the first time it's asked to play, so a page nobody swipes to fetches nothing.
-    private func prepareIfNeeded() {
-        guard player.currentItem == nil, let source = video.sources.first else { return }
+    ///
+    /// Nothing starts until the audio is off the item, since the point of the delay is to keep the
+    /// player from ever asking for the audio session.
+    private func prepare() {
+        guard preparation == nil, let source = video.sources.first else { return }
 
-        let item = AVPlayerItem(url: source.url)
-        player.replaceCurrentItem(with: item)
+        preparation = Task {
+            let item = await silencedItem(for: source.url)
+            guard !Task.isCancelled else { return }
 
+            observe(item)
+            player.replaceCurrentItem(with: item)
+            preparation = nil
+
+            if shouldPlay {
+                player.play()
+            }
+
+            await loadAspectRatio()
+
+            if let captionsUrl = video.captionsUrl {
+                await loadCaptions(from: captionsUrl)
+            }
+        }
+    }
+
+    /// The video with its audio left out rather than turned down.
+    ///
+    /// A muted player still activates the shared audio session, which interrupts whatever the
+    /// reader has playing in another app — the very thing muting is here to avoid. A stream is
+    /// silenced by deselecting the audio it offers, a file by playing a copy of its video track
+    /// alone.
+    private func silencedItem(for url: URL) async -> AVPlayerItem {
+        let asset = AVURLAsset(url: url)
+
+        if let videoOnly = await videoOnlyCopy(of: asset) {
+            return AVPlayerItem(asset: videoOnly)
+        }
+
+        let item = AVPlayerItem(asset: asset)
+        if let audible = try? await asset.loadMediaSelectionGroup(for: .audible) {
+            item.select(nil, in: audible)
+        }
+        return item
+    }
+
+    /// The asset's video track on its own, or `nil` for a stream, whose tracks aren't there to copy
+    /// and which has media selection to turn its audio off with instead.
+    private func videoOnlyCopy(of asset: AVURLAsset) async -> AVAsset? {
+        guard let source = try? await asset.loadTracks(withMediaType: .video).first,
+              let duration = try? await asset.load(.duration) else { return nil }
+
+        let composition = AVMutableComposition()
+        guard let track = composition.addMutableTrack(withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid),
+              (try? track.insertTimeRange(CMTimeRange(start: .zero, duration: duration), of: source, at: .zero)) != nil
+        else { return nil }
+
+        // A copied track starts square-on, which would turn a video recorded on its side.
+        if let transform = try? await source.load(.preferredTransform) {
+            track.preferredTransform = transform
+        }
+
+        return composition
+    }
+
+    private func observe(_ item: AVPlayerItem) {
         endObserver = NotificationCenter.default.addObserver(forName: AVPlayerItem.didPlayToEndTimeNotification,
                                                             object: item,
                                                             queue: .main) { [weak self] _ in
@@ -216,12 +282,6 @@ private final class WhatsNewVideoPlayer: ObservableObject {
         statusObservation = item.observe(\.status) { [weak self] item, _ in
             guard item.status == .failed else { return }
             Task { @MainActor in self?.tearDown() }
-        }
-
-        Task { await loadAspectRatio() }
-
-        if let captionsUrl = video.captionsUrl {
-            Task { await loadCaptions(from: captionsUrl) }
         }
     }
 

--- a/podcasts/Whats New/Message/WhatsNewVideoView.swift
+++ b/podcasts/Whats New/Message/WhatsNewVideoView.swift
@@ -165,11 +165,29 @@ private final class WhatsNewVideoPlayer: ObservableObject {
         isPlaying ? stop() : play()
     }
 
+    /// AVFoundation traps on a player deallocated with a time observer still on it, and going away
+    /// without the page disappearing first — a scene disconnect, say — never reaches `tearDown()`.
+    deinit {
+        if let timeObserver {
+            player.removeTimeObserver(timeObserver)
+        }
+        if let endObserver {
+            NotificationCenter.default.removeObserver(endObserver)
+        }
+    }
+
     /// Puts the player back to how it started, so nothing is left loaded behind a page the reader
     /// has moved on from. Playing again loads it back.
     func tearDown() {
         stop()
+        removeObservers()
 
+        statusObservation = nil
+        caption = nil
+        player.replaceCurrentItem(with: nil)
+    }
+
+    private func removeObservers() {
         if let timeObserver {
             player.removeTimeObserver(timeObserver)
         }
@@ -178,9 +196,6 @@ private final class WhatsNewVideoPlayer: ObservableObject {
         }
         timeObserver = nil
         endObserver = nil
-        statusObservation = nil
-        caption = nil
-        player.replaceCurrentItem(with: nil)
     }
 
     /// Loads the video the first time it's asked to play, so a page nobody swipes to fetches nothing.

--- a/podcasts/Whats New/Message/WhatsNewVideoView.swift
+++ b/podcasts/Whats New/Message/WhatsNewVideoView.swift
@@ -107,7 +107,11 @@ struct WhatsNewVideoView: View {
 /// Drives the `AVPlayer` behind a video block.
 @MainActor
 private final class WhatsNewVideoPlayer: ObservableObject {
+    /// Whether the video is running, read from the player rather than from the last call into it,
+    /// so a pause the app didn't ask for — backgrounding, an interruption — still shows the play
+    /// button and takes a single tap to get going again.
     @Published private(set) var isPlaying = false
+
     @Published private(set) var caption: String?
 
     /// The video's shape, which starts at the widescreen these demos are recorded in and settles on
@@ -116,11 +120,16 @@ private final class WhatsNewVideoPlayer: ObservableObject {
 
     let player = AVPlayer()
 
+    /// Whether the video was last asked to play, which is what the loop turns on rather than the
+    /// player's own state: it's momentarily not playing at the end of every pass.
+    private var shouldPlay = false
+
     private let video: WhatsNewVideo
     private var captions: WhatsNewVideoCaptions?
     private var timeObserver: Any?
     private var endObserver: Any?
     private var statusObservation: NSKeyValueObservation?
+    private var playbackObservation: NSKeyValueObservation?
 
     init(video: WhatsNewVideo) {
         self.video = video
@@ -129,19 +138,27 @@ private final class WhatsNewVideoPlayer: ObservableObject {
         player.isMuted = true
         player.allowsExternalPlayback = false
         player.preventsDisplaySleepDuringVideoPlayback = false
+        // Looping is a seek back to the start, so the player is never asked to stop at the end and
+        // never drops out of playing between passes.
+        player.actionAtItemEnd = .none
+
+        playbackObservation = player.observe(\.timeControlStatus, options: [.initial, .new]) { player, _ in
+            let isPlaying = player.timeControlStatus != .paused
+            Task { @MainActor [weak self] in self?.isPlaying = isPlaying }
+        }
     }
 
     func play() {
         prepareIfNeeded()
         guard player.currentItem != nil else { return }
 
+        shouldPlay = true
         player.play()
-        isPlaying = true
     }
 
     func stop() {
+        shouldPlay = false
         player.pause()
-        isPlaying = false
     }
 
     func toggle() {
@@ -194,7 +211,7 @@ private final class WhatsNewVideoPlayer: ObservableObject {
 
     private func replay() {
         player.seek(to: .zero)
-        guard isPlaying else { return }
+        guard shouldPlay else { return }
         player.play()
     }
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3616,6 +3616,9 @@
 /* Navigation bar button on the What's New feed that marks every message in the list as read. */
 "whats_new_feed_read_all" = "Read all";
 
+/* VoiceOver label for a video in a What's New message that was published without a description of its own. */
+"whats_new_message_video" = "Video";
+
 /* Widget prompt title to direct the user to the discover tab to add new podcasts to their queue */
 "widgets_discover_prompt_title" = "Nothing in Up Next";
 


### PR DESCRIPTION
| 📘 Part of: What's New Messages |
|:---:|

Part of PCIOS-927, PCIOS-928

Opens a feed row onto its message: a horizontal pager over `content.pages` with page indicators (hidden for single-page messages), each page scrolling vertically under a translucent navigation bar. Renders every block the app models — `heading`, `paragraph`, `image` (sized from the published `width`/`height` so the page doesn't reflow on load), `video`, and `action`. Tapping a row pushes the detail and marks the message read.

Videos autoplay muted and looping over their poster, only while their page is on screen; Reduce Motion, Low Power Mode, or a load failure leaves the poster up with a play button. The audio is taken off the item rather than only muted, since a muted player still claims the shared audio session and would interrupt whatever is playing in another app. Sidecar WebVTT captions are parsed with SwiftSubtitles, already used by transcripts.

Decisions worth flagging:

- **The action allowlist is by scheme.** `WhatsNewLink` resolves a URL before the button is drawn: `pktc://` routes as a deep link, `https://` opens in an in-app Safari view, everything else is dropped and logged with no button rendered. A host allowlist would break research links to third-party surveys. This answers the plan's open "link/deep-link allowlist" question.
- **`pocketcasts://` is accepted as an alias for `pktc://`**, since the plan's examples use it and the app doesn't register it. The feed could publish `pktc://` instead and the alias would go.
- **Actions are pinned to the bottom of the page** rather than drawn where the catalog put them, so a button stays reachable however far the content scrolls.
- **Media is capped at ~52% of the page height**, so portrait screenshots narrow instead of pushing text off screen while landscape images still fill the width.
- **A message this build can't draw never reaches the feed.** Every block on a page can be dropped — an action the allowlist rejects is the app's own doing — and a message left with no pages would open onto an empty pager.
- **Read state stays in the feed view model**, the only path onto this screen; syncing is PCIOS-924, analytics PCIOS-933, and `poll` stays dropped by decoding until its contract exists.

The mock catalog gains a `known_issue` message built around a video and a long release notes message that has to scroll, and its media now points at assets that actually load, so the previews render something.

## To test

No entry point yet (PCIOS-925), so this is reviewed through the previews:

1. `WhatsNewFeedView.swift` → "Feed in a navigation controller". Tap a row — the message opens and its dot clears when you come back.
2. `WhatsNewMessageView.swift`: "Multiple pages" swipes with the dots tracking, "Try transcripts" switches to the Podcasts tab, "A single page" shows no dots, "A long page" scrolls under the bar with its button staying put, "A video demo" plays.
3. `WhatsNewMessageView_Previews` renders the secondary call to action once per theme.
4. `WhatsNewVideoView.swift` previews — check autoplay, tap to pause, and looping, and that a podcast playing in another app keeps going.
5. Turn on Reduce Motion or Low Power Mode and reopen a video: it waits on its poster until tapped.
6. At the largest accessibility text size, text grows and the page scrolls instead of clipping.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
