### PR TITLE
Enable network discovery for everyone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Fix the Chromecast button being invisible in the fullscreen video player [#5060](https://github.com/Automattic/pocket-casts-ios/pull/5060)
 - Fix a memory leak that kept the episode details screen, its views and artwork in memory after it was closed [#5067](https://github.com/Automattic/pocket-casts-ios/pull/5067)
 - Fix the controls in the fullscreen video player being too small to tap reliably [#5059](https://github.com/Automattic/pocket-casts-ios/pull/5059)
+- Add podcast networks to Discover: a "Networks" row on the Discover tab, the full grid of networks behind "Show All", and a page for each network listing the podcasts it carries [#5026](https://github.com/Automattic/pocket-casts-ios/pull/5026) [#5064](https://github.com/Automattic/pocket-casts-ios/pull/5064) [#5065](https://github.com/Automattic/pocket-casts-ios/pull/5065)
+- Add networks to search: a matching network now shows up in Top Results, and a "Networks" filter appears when the term matches one [#5036](https://github.com/Automattic/pocket-casts-ios/pull/5036)
+- Open a podcast's network from the podcast page, either from the author in the header or from the author row in the details below it [#5040](https://github.com/Automattic/pocket-casts-ios/pull/5040) [#5075](https://github.com/Automattic/pocket-casts-ios/pull/5075)
+- [tvOS] Add networks to search, in Combined Results and in a tab of their own [#5037](https://github.com/Automattic/pocket-casts-ios/pull/5037)
 
 8.20
 -----
@@ -17,8 +21,6 @@
 - Fix a rare crash when starting episode downloads [#5001](https://github.com/Automattic/pocket-casts-ios/pull/5001)
 - Fix a rare crash on the Apple Watch while downloading episodes in the background [#5002](https://github.com/Automattic/pocket-casts-ios/pull/5002)
 - Tapping a Discover collection's poster now opens the expanded collection, the same as tapping "Show All" [#5028](https://github.com/Automattic/pocket-casts-ios/pull/5028)
-- Add support for "Networks" row in "Discover" [#5026](https://github.com/Automattic/pocket-casts-ios/pull/5026)
-- Add networks to search, including "Combined Results" and a new dedicated tab/filter [#5037](https://github.com/Automattic/pocket-casts-ios/pull/5037)
 - Fix the Download button doing nothing in Search and Discover episode results [#4702](https://github.com/Automattic/pocket-casts-ios/pull/4702)
 - Fix a rare crash when the What's New screen was shown while another screen was still being dismissed [#5003](https://github.com/Automattic/pocket-casts-ios/pull/5003)
 

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -451,7 +451,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .sleepTimerLiveActivity:
             true
         case .networkDiscovery:
-            BuildEnvironment.current == .debug
+            true
         case .newEpisodeNotificationsPushOptOut:
             true
         case .whatsNewFeed:


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Turns `networkDiscovery` on by default, so the network work that has been landing behind the flag ships to everyone: the "Networks" row and grid in Discover, a page per network, networks in search, and the network links on the podcast page.

`CHANGELOG.md` gains the user-facing entries for that work, listed under 8.21 — the release the feature actually becomes visible in. The two network lines that were written under 8.20 (#5026, #5037) are moved into that list: 8.20 shipped with the flag off, so nobody saw those changes.

Still open and not required by this PR: #5066, #5075 and #5076 are refinements on top.

## To test

1. Run a **staging** release build (or turn the flag off and on under Profile → Settings → Developer → Feature Flags to compare).
2. Discover shows the **Networks** row; "Show All" opens the grid, and tapping a network opens its page with the podcast grid and working follow buttons.
3. Search for a network (e.g. `WNYC`): the network appears in Top Results and a **Networks** filter pill shows up.
4. Open a podcast that belongs to a network and pull to refresh: the author in the header, and the author row in the details box, are tinted and open the network's page.
5. Repeat on tvOS search.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGuVU4nMDm3EhtkXqysmTS
