### PR TITLE
Auto download episodes added to a manual playlist

### DIFF
--- a/PocketCastsTests/Tests/Playlists/PlaylistManagerAutoDownloadTests.swift
+++ b/PocketCastsTests/Tests/Playlists/PlaylistManagerAutoDownloadTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+import PocketCastsDataModel
+@testable import podcasts
+
+final class PlaylistManagerAutoDownloadTests: DBTestCase {
+    func testQueuesEpisodeAddedToManualPlaylist() throws {
+        let playlist = makeManualPlaylist(autoDownload: true)
+        let episode = makeEpisode()
+        dataManager.add(episodes: [episode], to: playlist)
+
+        let queued = PlaylistManager.queueAutoDownloads(for: playlist, downloadsAllowedNow: false, dataManager: dataManager, downloadManager: downloadManager)
+
+        XCTAssertEqual(queued, [episode.uuid])
+        let refreshed = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertEqual(refreshed.episodeStatus, DownloadStatus.waitingForWifi.rawValue)
+        XCTAssertEqual(refreshed.autoDownloadStatus, AutoDownloadStatus.autoDownloaded.rawValue)
+    }
+
+    func testDownloadsImmediatelyWhenConnectionAllowsIt() throws {
+        let playlist = makeManualPlaylist(autoDownload: true)
+        let episode = makeEpisode()
+        dataManager.add(episodes: [episode], to: playlist)
+
+        let queued = PlaylistManager.queueAutoDownloads(for: playlist, downloadsAllowedNow: true, dataManager: dataManager, downloadManager: downloadManager)
+
+        XCTAssertEqual(queued, [episode.uuid])
+        let refreshed = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertEqual(refreshed.episodeStatus, DownloadStatus.queued.rawValue)
+        XCTAssertEqual(refreshed.autoDownloadStatus, AutoDownloadStatus.autoDownloaded.rawValue)
+    }
+
+    func testIgnoresManualPlaylistWithAutoDownloadOff() throws {
+        let playlist = makeManualPlaylist(autoDownload: false)
+        let episode = makeEpisode()
+        dataManager.add(episodes: [episode], to: playlist)
+
+        let queued = PlaylistManager.queueAutoDownloads(for: playlist, downloadsAllowedNow: false, dataManager: dataManager, downloadManager: downloadManager)
+
+        XCTAssertTrue(queued.isEmpty)
+        let refreshed = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertEqual(refreshed.episodeStatus, DownloadStatus.notDownloaded.rawValue)
+        XCTAssertEqual(refreshed.autoDownloadStatus, AutoDownloadStatus.notSpecified.rawValue)
+    }
+
+    /// Turning auto download on for a playlist that already has episodes should download them,
+    /// not just the ones added afterwards.
+    func testQueuesEpisodesAlreadyInThePlaylist() throws {
+        let playlist = makeManualPlaylist(autoDownload: false)
+        let episode = makeEpisode()
+        dataManager.add(episodes: [episode], to: playlist)
+
+        playlist.autoDownloadEpisodes = true
+        dataManager.save(playlist: playlist)
+
+        let queued = PlaylistManager.queueAutoDownloads(for: playlist, downloadsAllowedNow: false, dataManager: dataManager, downloadManager: downloadManager)
+
+        XCTAssertEqual(queued, [episode.uuid])
+        let refreshed = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertEqual(refreshed.episodeStatus, DownloadStatus.waitingForWifi.rawValue)
+    }
+
+    func testSkipsEpisodesAlreadyQueued() throws {
+        let playlist = makeManualPlaylist(autoDownload: true)
+        let episode = makeEpisode(status: .queued)
+        dataManager.add(episodes: [episode], to: playlist)
+
+        let queued = PlaylistManager.queueAutoDownloads(for: playlist, downloadsAllowedNow: false, dataManager: dataManager, downloadManager: downloadManager)
+
+        XCTAssertTrue(queued.isEmpty)
+        let refreshed = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertEqual(refreshed.autoDownloadStatus, AutoDownloadStatus.notSpecified.rawValue)
+    }
+
+    func testSkipsEpisodesAlreadyDownloaded() throws {
+        let playlist = makeManualPlaylist(autoDownload: true)
+        let episode = makeEpisode(status: .downloaded)
+        createDownloadedFile(for: episode)
+        dataManager.add(episodes: [episode], to: playlist)
+
+        let queued = PlaylistManager.queueAutoDownloads(for: playlist, downloadsAllowedNow: false, dataManager: dataManager, downloadManager: downloadManager)
+
+        XCTAssertTrue(queued.isEmpty)
+        let refreshed = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertEqual(refreshed.episodeStatus, DownloadStatus.downloaded.rawValue)
+    }
+
+    func testRespectsTheAutoDownloadLimit() throws {
+        let playlist = makeManualPlaylist(autoDownload: true)
+        playlist.autoDownloadLimit = 1
+        dataManager.save(playlist: playlist)
+
+        let episodes = [makeEpisode(), makeEpisode()]
+        dataManager.add(episodes: episodes, to: playlist)
+
+        let queued = PlaylistManager.queueAutoDownloads(for: playlist, downloadsAllowedNow: false, dataManager: dataManager, downloadManager: downloadManager)
+
+        XCTAssertEqual(queued.count, 1)
+    }
+
+    func testCheckForAutoDownloadsInPlaylistQueuesAndNotifies() throws {
+        let playlist = makeManualPlaylist(autoDownload: true)
+        let episode = makeEpisode()
+        dataManager.add(episodes: [episode], to: playlist)
+
+        let notified = expectation(forNotification: Constants.Notifications.manyEpisodesChanged, object: nil)
+
+        PlaylistManager.checkForAutoDownloads(in: playlist)
+
+        wait(for: [notified], timeout: 5)
+        let refreshed = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertEqual(refreshed.autoDownloadStatus, AutoDownloadStatus.autoDownloaded.rawValue)
+        XCTAssertNotEqual(refreshed.episodeStatus, DownloadStatus.notDownloaded.rawValue)
+    }
+
+    // MARK: - Helpers
+
+    private func makeManualPlaylist(autoDownload: Bool) -> EpisodeFilter {
+        let playlist = EpisodeFilter.makeDefault()
+        playlist.playlistName = "Manual Playlist"
+        playlist.manual = true
+        playlist.sortType = PlaylistSort.dragAndDrop.rawValue
+        playlist.autoDownloadEpisodes = autoDownload
+        dataManager.save(playlist: playlist)
+
+        return playlist
+    }
+
+    private func makeEpisode(status: DownloadStatus = .notDownloaded) -> Episode {
+        let episode = Episode()
+        episode.uuid = UUID().uuidString
+        episode.podcastUuid = podcast.uuid
+        episode.podcast_id = podcast.id
+        episode.addedDate = Date()
+        episode.publishedDate = Date()
+        episode.downloadUrl = "http://example.com/audio"
+        episode.playingStatus = PlayingStatus.notPlayed.rawValue
+        episode.episodeStatus = status.rawValue
+        dataManager.save(episode: episode)
+
+        return episode
+    }
+
+    private func createDownloadedFile(for episode: Episode) {
+        let path = downloadManager.pathForEpisode(episode)
+        let directory = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: path, contents: Data())
+    }
+}

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -189,6 +189,7 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
                 playlist.autoDownloadLimit = playlist.maxAutoDownloadEpisodes()
                 DataManager.sharedManager.save(playlist: playlist)
                 NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged, object: playlist)
+                PlaylistManager.checkForAutoDownloads(in: playlist)
             }
             playlistSelectionViewController.playlistUnselected = { playlist in
                 Analytics.track(.filterAutoDownloadUpdated, properties: ["enabled": false, "source": AnalyticsSource.autoDownloadSettings])

--- a/podcasts/FilterEditOptionsViewController.swift
+++ b/podcasts/FilterEditOptionsViewController.swift
@@ -66,6 +66,7 @@ class FilterEditOptionsViewController: PCViewController, UITableViewDelegate, UI
         filterToEdit.syncStatus = SyncStatus.notSynced.rawValue
         DataManager.sharedManager.save(playlist: filterToEdit)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged, object: filterToEdit)
+        PlaylistManager.checkForAutoDownloads(in: filterToEdit)
 
         if isViewingShortcuts == false {
             let properties = ["did_change_name": didChangeName,

--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -245,6 +245,8 @@ class NewPlaylistViewController: PCViewController {
                 return
             }
 
+            PlaylistManager.checkForAutoDownloads(in: playlist)
+
             Analytics.track(.addToPlaylistsCreateNewPlaylistTapped, properties: ["source": analyticsSource ?? "unknown"])
 
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged, object: playlist)
@@ -284,6 +286,8 @@ class NewPlaylistViewController: PCViewController {
                 Toast.show(L10n.playlistManualCreateErrorMessage, theme: theme)
                 return
             }
+
+            PlaylistManager.checkForAutoDownloads(in: playlist)
 
             Analytics.track(.addToPlaylistsCreateNewPlaylistTapped, properties: ["source": analyticsSource ?? "unknown"])
 

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -205,6 +205,7 @@ class ManualPlaylistsChooserViewController: PCViewController {
         changedPlaylists.forEach { playlist in
             playlist.syncStatus = SyncStatus.notSynced.rawValue
             dataManager.save(playlist: playlist)
+            PlaylistManager.checkForAutoDownloads(in: playlist)
         }
 
         let showAddedToast = !added.isEmpty && !changedPlaylists.isEmpty

--- a/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
@@ -164,6 +164,8 @@ final class LocalSearchCoordinator {
                 return
             }
 
+            PlaylistManager.checkForAutoDownloads(in: playlist)
+
             // For now let's track the event directly here to avoid swift concurrency warning using the PlaylistTypeTrackerProvider
             Analytics.track(
                 .episodeAddedToList,

--- a/podcasts/PlaylistManager.swift
+++ b/podcasts/PlaylistManager.swift
@@ -93,24 +93,54 @@ class PlaylistManager {
 
         if playlists.isEmpty { return }
 
-        let onWifi = NetworkUtils.shared.isConnectedToUnexpensiveConnection()
-        let mobileDataAllowed = Settings.autoDownloadMobileDataAllowed()
+        let downloadsAllowedNow = downloadsAllowedNow()
         for playlist in playlists {
-            guard playlist.autoDownloadEpisodes else { continue }
+            queueAutoDownloads(for: playlist, downloadsAllowedNow: downloadsAllowedNow)
+        }
+    }
 
-            let query = PlaylistQueryBuilder.query(clause: .episode, for: playlist, episodeUuidToAdd: playlist.episodeUuidToAddToQueries(), limit: Int(playlist.maxAutoDownloadEpisodes()))
-            let episodes = DataManager.sharedManager.findPlaylistEpisodesWhere(query: query, arguments: nil)
+    /// Checks a single playlist for episodes that need auto downloading, off the main thread.
+    ///
+    /// Call this whenever the contents of a playlist change outside of a sync, or when auto
+    /// download is switched on for it.
+    class func checkForAutoDownloads(in playlist: EpisodeFilter) {
+        guard playlist.autoDownloadEpisodes else { return }
 
-            for episode in episodes {
-                if episode.downloaded(pathFinder: DownloadManager.shared) || episode.queued() { continue }
+        DispatchQueue.global(qos: .userInitiated).async {
+            let queued = queueAutoDownloads(for: playlist, downloadsAllowedNow: downloadsAllowedNow())
 
-                if !onWifi, !mobileDataAllowed {
-                    DownloadManager.shared.queueForLaterDownload(episodeUuid: episode.uuid, fireNotification: false, autoDownloadStatus: .autoDownloaded)
-                } else {
-                    DownloadManager.shared.addToQueue(episodeUuid: episode.uuid, fireNotification: false, autoDownloadStatus: .autoDownloaded)
-                }
+            if !queued.isEmpty {
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
             }
         }
+    }
+
+    /// Queues the episodes of `playlist` that auto download covers but that aren't downloaded or
+    /// queued yet. Returns the uuids of the episodes it queued.
+    @discardableResult
+    class func queueAutoDownloads(for playlist: EpisodeFilter, downloadsAllowedNow: Bool, dataManager: DataManager = .sharedManager, downloadManager: DownloadManager = .shared) -> [String] {
+        guard playlist.autoDownloadEpisodes else { return [] }
+
+        let query = PlaylistQueryBuilder.query(clause: .episode, for: playlist, episodeUuidToAdd: playlist.episodeUuidToAddToQueries(), limit: Int(playlist.maxAutoDownloadEpisodes()))
+        let episodes = dataManager.findPlaylistEpisodesWhere(query: query, arguments: nil)
+
+        var queuedUuids: [String] = []
+        for episode in episodes {
+            if episode.downloaded(pathFinder: downloadManager) || episode.queued() { continue }
+
+            if downloadsAllowedNow {
+                downloadManager.addToQueue(episodeUuid: episode.uuid, fireNotification: false, autoDownloadStatus: .autoDownloaded)
+            } else {
+                downloadManager.queueForLaterDownload(episodeUuid: episode.uuid, fireNotification: false, autoDownloadStatus: .autoDownloaded)
+            }
+            queuedUuids.append(episode.uuid)
+        }
+
+        return queuedUuids
+    }
+
+    private class func downloadsAllowedNow() -> Bool {
+        NetworkUtils.shared.isConnectedToUnexpensiveConnection() || Settings.autoDownloadMobileDataAllowed()
     }
 
     class func handlePodcastUnsubscribed(podcastUuid: String) {


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-946

Turning on **Auto Download** in Playlist Options for a manual playlist had no effect until the next server sync: the user had to tap download on each episode manually.

`PlaylistManager.checkForAutoDownloads()` was only ever invoked from `ServerSyncManager.performActionsAfterSync()`. Adding an episode to a manual playlist goes through `DataManager.add(episodes:to:)`, which writes the join rows and nothing else, so nothing queued a download. The auto-download logic itself was already correct for manual playlists — `PlaylistQueryBuilder.query(clause:for:...)` branches on `playlist.manual`, and `EpisodeFilter.maxAutoDownloadEpisodes()` falls back to `Constants.Values.defaultPlaylistDownloadLimit`.

### What changed

`PlaylistManager` gains a per-playlist entry point:

- `queueAutoDownloads(for:downloadsAllowedNow:dataManager:downloadManager:)` holds the logic that used to be inline in the loop, with the dependencies injectable so it can be unit tested. It keeps the existing wifi/mobile-data gate (`NetworkUtils.shared.isConnectedToUnexpensiveConnection()` / `Settings.autoDownloadMobileDataAllowed()`) and the `queueForLaterDownload` vs `addToQueue` split, and still skips episodes that are already downloaded or queued.
- `checkForAutoDownloads(in:)` runs that off the main thread and posts `manyEpisodesChanged` when it queued anything, so the episode rows pick up the new download state.
- `checkForAutoDownloads()` (the sync path) is now a loop over the same function. Its behaviour is unchanged.

It is called from every path that adds episodes to a manual playlist:

- `ManualPlaylistsChooserViewController.doneTapped()` — single and multi-episode. This also covers `MultiSelectHelper.addToPlaylist` and the `SwipeActionsHelper` add-to-playlist swipe, which both present this chooser.
- `LocalSearchCoordinator.handleAddEpisode` — the search screen `PlaylistDetailViewController.addEpisodes()` presents.
- `NewPlaylistViewController` — both the `.addEpisode` and `.addEpisodes` creation branches. `EpisodeFilter.makeDefault()` leaves auto download off, so this is a no-op today; it's here so the invariant holds at every add path rather than depending on that default.

### Turning the toggle on downloads existing episodes

The reporter's screenshot implies they expect flipping the switch to download what's already in the playlist, not just what they add afterwards. **That is the behaviour shipped here.** `FilterEditOptionsViewController.viewWillDisappear` and the playlist picker in `DownloadSettingsViewController` both run the check after saving, and it scans the whole playlist up to the auto-download limit. It is idempotent — episodes already downloaded or queued are skipped — so dismissing the options screen repeatedly costs one query.

### Related

`PCIOS-867` (PR #5057, in progress) is a `downloadTaskId` race between `addToQueue` and `clearStuckDownloads()` that can silently drop an auto-download that did start. It compounds this bug: with this PR the downloads are now queued promptly, but until #5057 lands some of them can still be dropped on a background-refresh launch. Worth landing both before closing out the user report.

## To test

1. Create a manual playlist and add a couple of episodes to it.
2. Open **Playlist Options** and turn **Auto Download** on, then leave the screen.
3. The episodes already in the playlist start downloading.
4. Add another episode to the playlist — via the playlist's "Add Episodes" search, the episode detail "Add to Playlist", a swipe on an episode row, or multi-select — and confirm it starts downloading straight away, without waiting for a sync.
5. Repeat step 4 with **Settings → Downloads → Only on WiFi** and mobile data active: the episode should show *Waiting for WiFi* rather than downloading.
6. Turn Auto Download off and add another episode: nothing should download.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELNEVm8HCgqS7qJhhhvcmC
