### PR TITLE
Switch to version 2 of the combined search endpoint

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/Search/CombinedSearchTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Search/CombinedSearchTask.swift
@@ -58,7 +58,7 @@ public class CombinedSearchTask {
     }
 
     public func search(term: String) async throws -> [CombinedSearchResultType] {
-        let components = URLComponents(string: ServerConstants.Urls.cache() + "search/combined")
+        let components = URLComponents(string: ServerConstants.Urls.cache() + "v2/search/combined")
         guard let searchURL = components?.url,
               let request = ServerHelper.createJsonRequest(url: searchURL, params: ["term": term], timeout: 10, cachePolicy: .reloadIgnoringCacheData)
         else {

--- a/Modules/Tests/PocketCastsServerTests/CombinedSearchNetworkTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/CombinedSearchNetworkTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import XCTest
 
 final class CombinedSearchNetworkTests: XCTestCase {
-    /// A payload shaped like the one `search/combined` returns for a term matching a network.
+    /// A payload shaped like the one `v2/search/combined` returns for a term matching a network.
     private let json = """
     {
       "results": [


### PR DESCRIPTION
Search now asks the server for the newer version of the combined search results, so podcast networks keep appearing alongside podcasts and episodes.

Older Pocket Casts clients do not understand the `network` result type and crash when the server returns one. To fix that, the server has stopped returning network results from the original combined search route and serves them from a new versioned route instead ([PCSERVE-828](https://linear.app/a8c/issue/PCSERVE-828/add-new-combined-search-endpoint-to-avoid-client-crashes), [pocket-casts-podcast-api#381](https://github.com/Automattic/pocket-casts-podcast-api/pull/381)). This app already decodes and shows network results, so it needs to call the new route to keep receiving them.

`CombinedSearchTask` now posts to `v2/search/combined`. The request parameters and the response payload are unchanged, so nothing else needed to move.

<img width="350" src="https://github.com/user-attachments/assets/ec56b3d0-8038-4ceb-9836-fd054d901c0b" />

## To test

1. Open Search and search for a term that matches a network, for example `relay`.
1. Confirm podcast, episode and network results are all returned, and that network rows appear.
1. Tap a network result and confirm it opens the network page as before.
1. Search for a term with no network match and confirm podcast and episode results are unaffected.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

