### PR TITLE
Add the What's New entry point to Profile

### DIFF
--- a/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
@@ -88,7 +88,42 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.hasUnreadItems)
     }
 
+    /// The Profile row hands over an empty feed, so nothing shows until the catalog arrives.
+    func testLoadingFillsTheFeedFromTheCatalog() async {
+        let viewModel = WhatsNewFeedViewModel(catalogTask: catalogTask(publishing: Self.catalogJSON))
+        XCTAssertTrue(viewModel.items.isEmpty)
+
+        await viewModel.load()
+
+        XCTAssertEqual(viewModel.items.map(\.title), ["Sort your Up Next"])
+    }
+
+    /// Reads live in memory until read-state sync lands, so a refresh must not undo them.
+    func testReloadingTheCatalogKeepsWhatWasRead() async throws {
+        let viewModel = WhatsNewFeedViewModel(catalogTask: catalogTask(publishing: Self.catalogJSON))
+        await viewModel.load()
+        viewModel.select(try XCTUnwrap(viewModel.items.first))
+
+        await viewModel.load()
+
+        XCTAssertFalse(viewModel.hasUnreadItems)
+    }
+
+    /// A feed built from messages the caller already has never goes to the network.
+    func testLoadingAFeedBuiltFromMessagesLeavesItAlone() async {
+        let viewModel = WhatsNewFeedViewModel(messages: messages)
+
+        await viewModel.load()
+
+        XCTAssertEqual(viewModel.items.count, messages.count)
+    }
+
     // MARK: - Helpers
+
+    override func tearDown() {
+        StubURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
 
     private func decodedMessages(json: String) throws -> [WhatsNewMessage] {
         let decoder = JSONDecoder()
@@ -96,4 +131,68 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
 
         return try decoder.decode(WhatsNewCatalog.self, from: Data(json.utf8)).messages
     }
+
+    private func catalogTask(publishing json: String) -> WhatsNewCatalogTask {
+        StubURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(json.utf8))
+        }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+
+        let directory = URL.temporaryDirectory.appending(path: "whats-new-tests-\(UUID().uuidString)", directoryHint: .isDirectory)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        return WhatsNewCatalogTask(session: URLSession(configuration: configuration),
+                                   cache: WhatsNewCatalogCache(directory: directory))
+    }
+
+    private static let catalogJSON = """
+    {
+      "schemaVersion": 1,
+      "messages": [
+        {
+          "id": "01K2Y08DAWG9N7XJZX5QTH9Z0K",
+          "type": "tip",
+          "publishedAt": "2026-08-17T08:00:00Z",
+          "targeting": { "audiences": [] },
+          "summary": { "title": "Sort your Up Next" },
+          "content": { "pages": [{ "blocks": [{ "type": "paragraph", "content": "…" }] }] }
+        }
+      ]
+    }
+    """
+}
+
+private final class StubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let requestHandler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (response, data) = try requestHandler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
 }

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -87,7 +87,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     private let settingsCellId = "SettingsCell"
     private let endOfYearPromptCell = "EndOfYearPromptCell"
 
-    enum TableRow { case informationalBanner, kidsProfile, referralsClaim, allStats, downloaded, starred, listeningHistory, help, uploadedFiles, endOfYearPrompt, bookmarks }
+    enum TableRow { case informationalBanner, kidsProfile, referralsClaim, whatsNew, allStats, downloaded, starred, listeningHistory, help, uploadedFiles, endOfYearPrompt, bookmarks }
 
     private lazy var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
         let viewModel = InformationalBannerViewModel(bannerType: .profile)
@@ -364,6 +364,9 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             return KidsProfileBannerTableCell()
         case .referralsClaim:
             return ReferralsClaimBannerTableCell()
+        case .whatsNew:
+            cell.settingsImage.image = UIImage(named: "mail")
+            cell.settingsLabel.text = L10n.whatsNew
         case .allStats:
             cell.settingsImage.image = UIImage(named: "profile-stats")
             cell.settingsLabel.text = L10n.settingsStats
@@ -440,6 +443,9 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             ReferralsCoordinator.shared.startClaimFlow(from: self) { [weak self] in
                 self?.profileTable.reloadData()
             }
+        case .whatsNew:
+            let feedViewController = WhatsNewFeedViewController(viewModel: WhatsNewFeedViewModel())
+            navigationController?.pushViewController(feedViewController, animated: true)
         case .allStats:
             let statsViewController = StatsViewController()
             navigationController?.pushViewController(statsViewController, animated: true)
@@ -492,6 +498,10 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     private func refreshTableData() {
         var data: [[ProfileViewController.TableRow]]
         data = [[.allStats, .downloaded, .uploadedFiles, .starred, .bookmarks, .listeningHistory, .help]]
+
+        if FeatureFlag.whatsNewFeed.enabled {
+            data[0].insert(.whatsNew, at: 0)
+        }
 
         if EndOfYear.isEndOfYearActive, EndOfYear.isEligible {
             data[0].insert(.endOfYearPrompt, at: 0)

--- a/podcasts/Whats New/Feed/WhatsNewFeedView.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedView.swift
@@ -29,6 +29,7 @@ struct WhatsNewFeedView: View {
             }
         }
         .background(theme.primaryUi02.ignoresSafeArea())
+        .task { await viewModel.load() }
     }
 }
 

--- a/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
@@ -28,18 +28,30 @@ struct WhatsNewFeedItem: Identifiable, Hashable {
 /// screen — or marks itself read on the way there.
 @MainActor
 final class WhatsNewFeedViewModel: ObservableObject {
-    @Published private(set) var items: [WhatsNewFeedItem]
+    @Published private(set) var items: [WhatsNewFeedItem] = []
 
     /// Called with the message a tapped row belongs to.
     var onSelect: ((WhatsNewMessage) -> Void)?
 
-    private let messages: [WhatsNewMessage]
+    private var messages: [WhatsNewMessage] = []
+    private var readMessageIDs: Set<String>
+    private let catalogTask: WhatsNewCatalogTask?
+
+    init(catalogTask: WhatsNewCatalogTask = WhatsNewCatalogTask()) {
+        self.catalogTask = catalogTask
+        readMessageIDs = []
+    }
 
     init(messages: [WhatsNewMessage], readMessageIDs: Set<String> = []) {
-        self.messages = messages
-            .filter(WhatsNewMessageViewModel.canRender)
-            .sorted { $0.publishedAt > $1.publishedAt }
-        items = self.messages.map { WhatsNewFeedItem(message: $0, isUnread: !readMessageIDs.contains($0.id)) }
+        catalogTask = nil
+        self.readMessageIDs = readMessageIDs
+        show(messages)
+    }
+
+    /// Fills the feed in from the published catalog, or from the cached copy when it can't be reached.
+    func load() async {
+        guard let catalogTask, let catalog = try? await catalogTask.catalog() else { return }
+        show(catalog.messages)
     }
 
     var hasUnreadItems: Bool {
@@ -54,13 +66,23 @@ final class WhatsNewFeedViewModel: ObservableObject {
     }
 
     func markAllAsRead() {
+        readMessageIDs.formUnion(items.map(\.id))
         for index in items.indices {
             items[index].isUnread = false
         }
     }
 
     private func markAsRead(_ id: WhatsNewFeedItem.ID) {
+        readMessageIDs.insert(id)
+
         guard let index = items.firstIndex(where: { $0.id == id }) else { return }
         items[index].isUnread = false
+    }
+
+    private func show(_ messages: [WhatsNewMessage]) {
+        self.messages = messages
+            .filter(WhatsNewMessageViewModel.canRender)
+            .sorted { $0.publishedAt > $1.publishedAt }
+        items = self.messages.map { WhatsNewFeedItem(message: $0, isUnread: !readMessageIDs.contains($0.id)) }
     }
 }


### PR DESCRIPTION
| 📘 Part of: What's New Messages |
|:---:|

Fixes PCIOS-925

Adds the What's New row to Profile, behind the `whatsNewFeed` flag, so the feed built in #5077 and #5078 finally has a way in. The row sits at the top of the Profile list and pushes `WhatsNewFeedViewController`.

The feed view model gains a second init that takes no messages and fetches the catalog itself: `load()` runs from the view's `.task`, asks `WhatsNewCatalogTask` for the published catalog (falling back to its cached copy when the network is out), and fills the list in. The `messages:` init stays for previews and tests and never touches the network.

Read state moves into a `readMessageIDs` set on the view model rather than living only in the item structs, so a reload doesn't resurrect dots the reader already cleared. It's still in-memory only — syncing is PCIOS-924.

Tests cover the three paths through the new init: the catalog fills an empty feed, a reload keeps what was read, and a message-backed feed is left alone. They run against a `URLProtocol` stub with an ephemeral cache directory.

## To test

1. Enable the `whatsNewFeed` flag in the developer/feature flag settings and restart.
2. Go to the Profile tab — **What's New** is the first row in the list.
3. Tap it. The feed loads from the published catalog and shows the messages with unread dots.
4. Open a message, go back — its dot is gone.
5. Leave the screen and come back. The feed reloads and the message you read stays read.
6. Turn on Airplane Mode and reopen the feed — the cached catalog still renders.
7. Turn the flag off — the row is gone from Profile.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
