### PR TITLE
Filter out What's New messages the user isn't targeted by

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewMessageFilter.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewMessageFilter.swift
@@ -1,0 +1,66 @@
+import Foundation
+import PocketCastsUtils
+
+/// Decides which of the catalog's messages a user is meant to see.
+///
+/// The CDN publishes one catalog per platform and locale, so every remaining rule — who a message
+/// is for, which builds can render it, and when it's live — travels on the message itself. Anything
+/// reading the feed has to apply the same rules, whether it's drawing the list or only deriving the
+/// unread dot, or a message could be counted unread on the Profile row and then be nowhere to be
+/// found in the feed it sends the user to.
+public struct WhatsNewMessageFilter {
+    /// The tier the account is on, which a message's audiences are matched against.
+    public let audience: WhatsNewAudience
+
+    /// The build the user is on, which a message's minimum app version is matched against, or `nil`
+    /// when it isn't a version this can make sense of.
+    public let appVersion: Version?
+
+    public init(audience: WhatsNewAudience, appVersion: Version?) {
+        self.audience = audience
+        self.appVersion = appVersion
+    }
+
+    /// The filter for the account signed in and the build it's running on.
+    public static var current: WhatsNewMessageFilter {
+        let appVersion = ServerConfig.shared.syncDelegate?.appVersion() ?? ""
+        return WhatsNewMessageFilter(audience: .current, appVersion: Version(appVersion))
+    }
+
+    /// Whether the message clears every rule it carries.
+    public func includes(_ message: WhatsNewMessage, at date: Date = Date()) -> Bool {
+        message.targeting.targets(audience) && isSupported(message) && isLive(message, at: date)
+    }
+
+    /// Whether the build is new enough for the message.
+    ///
+    /// A message with no minimum is for every build. A minimum that isn't a version, or a version
+    /// we can't tell what we're running against, hides the message: a message gated on a build is
+    /// usually pointing at something only that build has, so guessing is worse than staying quiet.
+    private func isSupported(_ message: WhatsNewMessage) -> Bool {
+        guard let minimumAppVersion = message.targeting.minimumAppVersion else { return true }
+        guard let appVersion, let minimum = Version(minimumAppVersion) else { return false }
+        return appVersion >= minimum
+    }
+
+    /// Whether the message is published and hasn't expired.
+    ///
+    /// The server leaves unpublished and expired messages out of the catalog it generates, but a
+    /// cached catalog can outlive one of its messages, so the dates are worth checking here too.
+    private func isLive(_ message: WhatsNewMessage, at date: Date) -> Bool {
+        guard message.publishedAt <= date else { return false }
+        guard let expiresAt = message.expiresAt else { return true }
+        return expiresAt > date
+    }
+}
+
+public extension WhatsNewAudience {
+    /// The audience the account currently falls into.
+    static var current: WhatsNewAudience {
+        switch SubscriptionHelper.activeTier {
+        case .plus: .plus
+        case .patron: .patron
+        case .none: .free
+        }
+    }
+}

--- a/Modules/Sources/PocketCastsUtils/Version.swift
+++ b/Modules/Sources/PocketCastsUtils/Version.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// A dotted numeric version, such as an app's `7.43` or a release's `7.43.1`.
+///
+/// Versions are compared component by component rather than as text, so `7.10` is newer than `7.9`
+/// rather than older, and a version is padded with zeros against a longer one, so `7.43` and
+/// `7.43.0` are the same version.
+public struct Version: Hashable, Comparable, LosslessStringConvertible, Sendable {
+    /// The version's components, most significant first, without the trailing zeros that don't
+    /// change which version it is.
+    public let components: [Int]
+
+    /// Parses a dotted numeric version, returning `nil` for anything that isn't one.
+    ///
+    /// Anything but digits and the dots between them is rejected rather than guessed at, leaving it
+    /// to the caller to decide what an unparsable version should mean.
+    public init?(_ description: String) {
+        var components: [Int] = []
+        for component in description.split(separator: ".", omittingEmptySubsequences: false) {
+            guard component.allSatisfy({ $0.isASCII && $0.isNumber }), let value = Int(component) else { return nil }
+            components.append(value)
+        }
+
+        guard !components.isEmpty else { return nil }
+
+        while components.count > 1, components.last == 0 {
+            components.removeLast()
+        }
+        self.components = components
+    }
+
+    public var description: String {
+        components.map(String.init).joined(separator: ".")
+    }
+
+    public static func < (lhs: Version, rhs: Version) -> Bool {
+        for index in 0 ..< max(lhs.components.count, rhs.components.count) {
+            let left = lhs.components[safe: index] ?? 0
+            let right = rhs.components[safe: index] ?? 0
+            if left != right { return left < right }
+        }
+        return false
+    }
+}

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewMessageFilterTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewMessageFilterTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+@testable import PocketCastsServer
+import PocketCastsUtils
+import XCTest
+
+final class WhatsNewMessageFilterTests: XCTestCase {
+    private let filter = WhatsNewMessageFilter(audience: .plus, appVersion: Version("8.10"))
+    private let now = Date(timeIntervalSince1970: 1_787_000_000)
+
+    // MARK: - Audience
+
+    func testAMessageAimedAtTheUsersTierIsShown() throws {
+        let message = try message(targeting: #"{ "audiences": ["plus", "patron"] }"#)
+
+        XCTAssertTrue(filter.includes(message, at: now))
+    }
+
+    func testAMessageAimedAtAnotherTierIsHidden() throws {
+        let message = try message(targeting: #"{ "audiences": ["free"] }"#)
+
+        XCTAssertFalse(filter.includes(message, at: now))
+    }
+
+    func testAMessageWithNoAudiencesIsShownToEveryone() throws {
+        let message = try message(targeting: "{}")
+
+        for audience in [WhatsNewAudience.free, .plus, .patron] {
+            let filter = WhatsNewMessageFilter(audience: audience, appVersion: Version("8.10"))
+            XCTAssertTrue(filter.includes(message, at: now), "\(audience) should see a message aimed at nobody in particular")
+        }
+    }
+
+    /// A tier published after this build shipped can't be evaluated, so the message stays hidden
+    /// rather than reaching everyone.
+    func testAMessageAimedOnlyAtAnUnknownTierIsHidden() throws {
+        let message = try message(targeting: #"{ "audiences": ["future_tier"] }"#)
+
+        XCTAssertFalse(filter.includes(message, at: now))
+    }
+
+    // MARK: - Minimum app version
+
+    func testABuildNewerThanTheMinimumIsShownTheMessage() throws {
+        let message = try message(targeting: #"{ "minimumAppVersion": "8.9" }"#)
+
+        XCTAssertTrue(filter.includes(message, at: now))
+    }
+
+    func testTheBuildTheMinimumAsksForIsShownTheMessage() throws {
+        let message = try message(targeting: #"{ "minimumAppVersion": "8.10" }"#)
+
+        XCTAssertTrue(filter.includes(message, at: now))
+    }
+
+    func testAnOlderBuildIsNotShownTheMessage() throws {
+        let message = try message(targeting: #"{ "minimumAppVersion": "8.11" }"#)
+
+        XCTAssertFalse(filter.includes(message, at: now))
+    }
+
+    /// Comparing the versions as text would put 8.10 before 8.9.
+    func testVersionComponentsAreComparedAsNumbers() throws {
+        let message = try message(targeting: #"{ "minimumAppVersion": "8.9.1" }"#)
+
+        XCTAssertTrue(filter.includes(message, at: now))
+    }
+
+    /// The build ships as 8.10, so a minimum written out as 8.10.0 asks for the same version.
+    func testATrailingZeroDoesNotMakeTheMinimumNewer() throws {
+        let message = try message(targeting: #"{ "minimumAppVersion": "8.10.0" }"#)
+
+        XCTAssertTrue(filter.includes(message, at: now))
+    }
+
+    func testAMessageGatedOnAVersionIsHiddenWhenTheAppVersionIsUnknown() throws {
+        let filter = WhatsNewMessageFilter(audience: .plus, appVersion: nil)
+        let gated = try message(targeting: #"{ "minimumAppVersion": "8.9" }"#)
+        let ungated = try message(targeting: "{}")
+
+        XCTAssertFalse(filter.includes(gated, at: now))
+        XCTAssertTrue(filter.includes(ungated, at: now), "A message with no minimum is still for every build")
+    }
+
+    func testAMessageGatedOnSomethingThatIsNotAVersionIsHidden() throws {
+        let message = try message(targeting: #"{ "minimumAppVersion": "8.10-beta" }"#)
+
+        XCTAssertFalse(filter.includes(message, at: now))
+    }
+
+    // MARK: - Publication and expiry
+
+    func testAMessageThatIsNotPublishedYetIsHidden() throws {
+        let message = try message(publishedAt: now.addingTimeInterval(1.hour))
+
+        XCTAssertFalse(filter.includes(message, at: now))
+    }
+
+    /// The server leaves expired messages out of the catalog, but a cached one can outlive them.
+    func testAnExpiredMessageIsHidden() throws {
+        let message = try message(expiresAt: now.addingTimeInterval(-1.hour))
+
+        XCTAssertFalse(filter.includes(message, at: now))
+    }
+
+    func testAMessageThatHasNotExpiredYetIsShown() throws {
+        let message = try message(expiresAt: now.addingTimeInterval(1.hour))
+
+        XCTAssertTrue(filter.includes(message, at: now))
+    }
+
+    func testAMessageWithNoExpiryNeverExpires() throws {
+        let message = try message()
+
+        XCTAssertTrue(filter.includes(message, at: now.addingTimeInterval(365.days)))
+    }
+
+    // MARK: - Helpers
+
+    private func message(targeting: String = "{}",
+                         publishedAt: Date? = nil,
+                         expiresAt: Date? = nil) throws -> WhatsNewMessage {
+        let expires = expiresAt.map { #", "expiresAt": "\#(iso8601(from: $0))""# } ?? ""
+        let json = """
+        {
+          "id": "01K2Y08DAWG9N7XJZX5QTH9Z0K",
+          "type": "tip",
+          "publishedAt": "\(iso8601(from: publishedAt ?? now.addingTimeInterval(-1.day)))"\(expires),
+          "targeting": \(targeting),
+          "summary": { "title": "Sort your Up Next" },
+          "content": { "pages": [{ "blocks": [{ "type": "paragraph", "content": "…" }] }] }
+        }
+        """
+        return try WhatsNewCatalog.decoder.decode(WhatsNewMessage.self, from: Data(json.utf8))
+    }
+
+    private func iso8601(from date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+}

--- a/Modules/Tests/PocketCastsUtilsTests/VersionTests.swift
+++ b/Modules/Tests/PocketCastsUtilsTests/VersionTests.swift
@@ -1,0 +1,51 @@
+@testable import PocketCastsUtils
+import XCTest
+
+final class VersionTests: XCTestCase {
+    func testParsesTheComponentsOfADottedVersion() throws {
+        XCTAssertEqual(Version("7")?.components, [7])
+        XCTAssertEqual(Version("7.43")?.components, [7, 43])
+        XCTAssertEqual(Version("7.43.1")?.components, [7, 43, 1])
+        XCTAssertEqual(Version("7.43.0.1")?.components, [7, 43, 0, 1])
+    }
+
+    func testRejectsAnythingThatIsNotADottedVersion() {
+        XCTAssertNil(Version(""))
+        XCTAssertNil(Version("7.43-beta"))
+        XCTAssertNil(Version("v7.43"))
+        XCTAssertNil(Version("7."))
+        XCTAssertNil(Version("7..1"))
+        XCTAssertNil(Version("7.43 (1234)"))
+        XCTAssertNil(Version("-7.43"))
+    }
+
+    /// Comparing versions as text would put 7.10 before 7.9.
+    func testOrdersComponentsAsNumbersRatherThanText() throws {
+        try XCTAssertGreaterThan(version("7.10"), version("7.9"))
+        try XCTAssertGreaterThan(version("7.43.10"), version("7.43.9"))
+        try XCTAssertLessThan(version("7.43"), version("8.0"))
+    }
+
+    func testAShorterVersionIsPaddedAgainstALongerOne() throws {
+        try XCTAssertEqual(version("7.43"), version("7.43.0"))
+        try XCTAssertEqual(version("7.43"), version("7.43.0.0"))
+        try XCTAssertLessThan(version("7.43"), version("7.43.1"))
+        try XCTAssertGreaterThan(version("7.43.1"), version("7.43"))
+    }
+
+    func testEqualVersionsHashTheSame() throws {
+        try XCTAssertEqual(Set([version("7.43"), version("7.43.0")]).count, 1)
+    }
+
+    /// The trailing zeros a version is written with aren't worth carrying, but everything the
+    /// version actually says has to survive the round trip.
+    func testDescriptionRoundTrips() throws {
+        try XCTAssertEqual(version("7.43.1").description, "7.43.1")
+        try XCTAssertEqual(version("7.43.0").description, "7.43")
+        try XCTAssertEqual(version("0").description, "0")
+    }
+
+    private func version(_ string: String) throws -> Version {
+        try XCTUnwrap(Version(string), "\(string) should parse as a version")
+    }
+}

--- a/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
@@ -1,4 +1,5 @@
 import PocketCastsServer
+import PocketCastsUtils
 import XCTest
 
 @testable import podcasts
@@ -7,15 +8,19 @@ import XCTest
 final class WhatsNewFeedViewModelTests: XCTestCase {
     private let messages = WhatsNewCatalog.mock.messages
 
+    /// The mock messages are targeted, so the tests fix the audience and the build rather than
+    /// letting whatever the test host is signed in as decide which of them reach the feed.
+    private let targeting = WhatsNewMessageFilter(audience: .free, appVersion: Version("8.10"))
+
     func testItemsAreMostRecentlyPublishedFirst() {
-        let viewModel = WhatsNewFeedViewModel(messages: messages.shuffled())
+        let viewModel = WhatsNewFeedViewModel(messages: messages.shuffled(), targeting: targeting)
 
         XCTAssertEqual(viewModel.items.map(\.publishedAt), messages.map(\.publishedAt).sorted(by: >))
     }
 
     /// The detail screen needs the whole message, not just what the row happened to show.
     func testSelectingARowHandsOverItsMessage() throws {
-        let viewModel = WhatsNewFeedViewModel(messages: messages)
+        let viewModel = WhatsNewFeedViewModel(messages: messages, targeting: targeting)
         var selected: WhatsNewMessage?
         viewModel.onSelect = { selected = $0 }
 
@@ -27,7 +32,7 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
 
     /// Opening the detail is what marks a message read.
     func testSelectingARowMarksItRead() throws {
-        let viewModel = WhatsNewFeedViewModel(messages: messages)
+        let viewModel = WhatsNewFeedViewModel(messages: messages, targeting: targeting)
 
         let item = try XCTUnwrap(viewModel.items.first)
         XCTAssertTrue(item.isUnread)
@@ -38,7 +43,7 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
     }
 
     func testReadMessagesStartRead() {
-        let viewModel = WhatsNewFeedViewModel(messages: messages, readMessageIDs: Set(messages.map(\.id)))
+        let viewModel = WhatsNewFeedViewModel(messages: messages, readMessageIDs: Set(messages.map(\.id)), targeting: targeting)
 
         XCTAssertFalse(viewModel.hasUnreadItems)
     }
@@ -74,13 +79,55 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
         }
         """)
 
-        let viewModel = WhatsNewFeedViewModel(messages: messages)
+        let viewModel = WhatsNewFeedViewModel(messages: messages, targeting: targeting)
 
         XCTAssertEqual(viewModel.items.map(\.title), ["Sort your Up Next"])
     }
 
+    /// The catalog is published per platform and locale, so the rest of the targeting is the
+    /// client's to apply — including to the unread count the Profile row is drawn from.
+    func testMessagesThisUserIsNotTargetedByNeverReachTheFeed() throws {
+        let messages = try decodedMessages(json: """
+        {
+          "schemaVersion": 1,
+          "messages": [
+            {
+              "id": "01K2Y08DAWG9N7XJZX5QTH9Z0K",
+              "type": "tip",
+              "publishedAt": "2026-08-17T08:00:00Z",
+              "targeting": { "audiences": [] },
+              "summary": { "title": "Sort your Up Next" },
+              "content": { "pages": [{ "blocks": [{ "type": "paragraph", "content": "…" }] }] }
+            },
+            {
+              "id": "01K2Y3D5J1H7QZP0B6RXKA4N3T",
+              "type": "announcement",
+              "publishedAt": "2026-08-18T08:00:00Z",
+              "targeting": { "audiences": ["patron"] },
+              "summary": { "title": "Thanks for being a Patron" },
+              "content": { "pages": [{ "blocks": [{ "type": "paragraph", "content": "…" }] }] }
+            },
+            {
+              "id": "01K2Y4H2P6R8T0VXZB1DFG3JKM",
+              "type": "new_feature",
+              "publishedAt": "2026-08-19T08:00:00Z",
+              "expiresAt": "2026-08-20T08:00:00Z",
+              "targeting": { "audiences": [], "minimumAppVersion": "9.0" },
+              "summary": { "title": "Something newer builds have" },
+              "content": { "pages": [{ "blocks": [{ "type": "paragraph", "content": "…" }] }] }
+            }
+          ]
+        }
+        """)
+
+        let viewModel = WhatsNewFeedViewModel(messages: messages, targeting: targeting)
+
+        XCTAssertEqual(viewModel.items.map(\.title), ["Sort your Up Next"])
+        XCTAssertTrue(viewModel.hasUnreadItems)
+    }
+
     func testReadingEverythingClearsEveryIndicator() {
-        let viewModel = WhatsNewFeedViewModel(messages: messages)
+        let viewModel = WhatsNewFeedViewModel(messages: messages, targeting: targeting)
         XCTAssertTrue(viewModel.hasUnreadItems)
 
         viewModel.markAllAsRead()
@@ -90,7 +137,7 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
 
     /// The Profile row hands over an empty feed, so nothing shows until the catalog arrives.
     func testLoadingFillsTheFeedFromTheCatalog() async {
-        let viewModel = WhatsNewFeedViewModel(catalogTask: catalogTask(publishing: Self.catalogJSON))
+        let viewModel = WhatsNewFeedViewModel(catalogTask: catalogTask(publishing: Self.catalogJSON), targeting: targeting)
         XCTAssertTrue(viewModel.items.isEmpty)
 
         await viewModel.load()
@@ -100,7 +147,7 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
 
     /// Reads live in memory until read-state sync lands, so a refresh must not undo them.
     func testReloadingTheCatalogKeepsWhatWasRead() async throws {
-        let viewModel = WhatsNewFeedViewModel(catalogTask: catalogTask(publishing: Self.catalogJSON))
+        let viewModel = WhatsNewFeedViewModel(catalogTask: catalogTask(publishing: Self.catalogJSON), targeting: targeting)
         await viewModel.load()
         viewModel.select(try XCTUnwrap(viewModel.items.first))
 
@@ -111,7 +158,7 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
 
     /// A feed built from messages the caller already has never goes to the network.
     func testLoadingAFeedBuiltFromMessagesLeavesItAlone() async {
-        let viewModel = WhatsNewFeedViewModel(messages: messages)
+        let viewModel = WhatsNewFeedViewModel(messages: messages, targeting: targeting)
 
         await viewModel.load()
 

--- a/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
@@ -24,8 +24,8 @@ struct WhatsNewFeedItem: Identifiable, Hashable {
 
 /// The messages the What's New feed shows, most recently published first.
 ///
-/// A message this build has nothing to draw never reaches the list, so no row opens onto an empty
-/// screen — or marks itself read on the way there.
+/// A message this build has nothing to draw, or that isn't aimed at this user, never reaches the
+/// list, so no row opens onto an empty screen — or marks itself read on the way there.
 @MainActor
 final class WhatsNewFeedViewModel: ObservableObject {
     @Published private(set) var items: [WhatsNewFeedItem] = []
@@ -36,14 +36,17 @@ final class WhatsNewFeedViewModel: ObservableObject {
     private var messages: [WhatsNewMessage] = []
     private var readMessageIDs: Set<String>
     private let catalogTask: WhatsNewCatalogTask?
+    private let targeting: WhatsNewMessageFilter
 
-    init(catalogTask: WhatsNewCatalogTask = WhatsNewCatalogTask()) {
+    init(catalogTask: WhatsNewCatalogTask = WhatsNewCatalogTask(), targeting: WhatsNewMessageFilter = .current) {
         self.catalogTask = catalogTask
+        self.targeting = targeting
         readMessageIDs = []
     }
 
-    init(messages: [WhatsNewMessage], readMessageIDs: Set<String> = []) {
+    init(messages: [WhatsNewMessage], readMessageIDs: Set<String> = [], targeting: WhatsNewMessageFilter = .current) {
         catalogTask = nil
+        self.targeting = targeting
         self.readMessageIDs = readMessageIDs
         show(messages)
     }
@@ -81,6 +84,7 @@ final class WhatsNewFeedViewModel: ObservableObject {
 
     private func show(_ messages: [WhatsNewMessage]) {
         self.messages = messages
+            .filter { targeting.includes($0) }
             .filter(WhatsNewMessageViewModel.canRender)
             .sorted { $0.publishedAt > $1.publishedAt }
         items = self.messages.map { WhatsNewFeedItem(message: $0, isUnread: !readMessageIDs.contains($0.id)) }


### PR DESCRIPTION
| 📘 Part of: What's New Messages |
|:---:|

Part of PCIOS-924 (the targeting half; read-state sync is still to come)

The CDN publishes one catalog per platform and locale, so the rest of the targeting is the client's to apply. `WhatsNewMessageFilter` is the one place that decides whether a message is meant for this user: its audiences against the account's tier, its `minimumAppVersion` against the running build, and its `publishedAt`/`expiresAt` against now. The dates are checked here rather than trusted to the catalog because a cached one can outlive a message.

`WhatsNewFeedViewModel` applies the filter before anything else, so it covers both the catalog and the messages-in-hand paths, and the unread count behind the Profile dot can never include a message the feed won't show.

`Version` (in `PocketCastsUtils`) parses a dotted version and compares it component by component — what comparing strings with `.numeric` doesn't give, since `8.1` and `8.1.0` are the same version but aren't equal as text. An unreadable version, an unparsable minimum, or an audience this build doesn't understand hides the message rather than guessing.

## To test

Targeting isn't visible without published test content, so this is mostly covered by the unit tests. To see it end to end:

1. Enable the `whatsNewFeed` flag and restart.
2. Point the app at a catalog with a message targeted at `["patron"]` and one with `"audiences": []`.
3. Open **Profile → What's New** on a free account — only the untargeted message is listed, and it's the only one the unread dot counts.
4. Add a message with `"minimumAppVersion"` above the running build — it doesn't appear. Set it to the running version, or that version with a `.0` on the end, and it does.
5. Add a message with an `expiresAt` in the past — it doesn't appear even once the catalog is cached and you're offline.

Unit tests: `PocketCastsUtilsTests/VersionTests`, `PocketCastsServerTests/WhatsNewMessageFilterTests`, `PocketCastsTests/WhatsNewFeedViewModelTests`.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGuVU4nMDm3EhtkXqysmTS
