### PR TITLE
Add loading, empty and error states to the What's New feed

### DIFF
--- a/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
@@ -92,9 +92,32 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
     func testLoadingFillsTheFeedFromTheCatalog() async {
         let viewModel = WhatsNewFeedViewModel(catalogTask: catalogTask(publishing: Self.catalogJSON))
         XCTAssertTrue(viewModel.items.isEmpty)
+        XCTAssertEqual(viewModel.state, .loading)
 
         await viewModel.load()
 
+        XCTAssertEqual(viewModel.items.map(\.title), ["Sort your Up Next"])
+        XCTAssertEqual(viewModel.state, .loaded)
+    }
+
+    /// With no cached copy to fall back to, a catalog that can't be reached is a failure, not an empty feed.
+    func testFailingToReachTheCatalogWithNothingCachedFails() async {
+        let viewModel = WhatsNewFeedViewModel(catalogTask: catalogTask())
+
+        await viewModel.load()
+
+        XCTAssertEqual(viewModel.state, .failed)
+        XCTAssertTrue(viewModel.items.isEmpty)
+    }
+
+    func testRetryingFillsTheFeedOnceTheCatalogCanBeReached() async {
+        let viewModel = WhatsNewFeedViewModel(catalogTask: catalogTask())
+        await viewModel.load()
+        publish(Self.catalogJSON)
+
+        await viewModel.retry()
+
+        XCTAssertEqual(viewModel.state, .loaded)
         XCTAssertEqual(viewModel.items.map(\.title), ["Sort your Up Next"])
     }
 
@@ -132,10 +155,10 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
         return try decoder.decode(WhatsNewCatalog.self, from: Data(json.utf8)).messages
     }
 
-    private func catalogTask(publishing json: String) -> WhatsNewCatalogTask {
-        StubURLProtocol.requestHandler = { request in
-            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
-            return (response, Data(json.utf8))
+    /// A catalog task that answers with `json`, or fails every request until something is published.
+    private func catalogTask(publishing json: String? = nil) -> WhatsNewCatalogTask {
+        if let json {
+            publish(json)
         }
 
         let configuration = URLSessionConfiguration.ephemeral
@@ -148,6 +171,13 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
 
         return WhatsNewCatalogTask(session: URLSession(configuration: configuration),
                                    cache: WhatsNewCatalogCache(directory: directory))
+    }
+
+    private func publish(_ json: String) {
+        StubURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(json.utf8))
+        }
     }
 
     private static let catalogJSON = """

--- a/podcasts/Whats New/Feed/WhatsNewFeedView.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedView.swift
@@ -28,8 +28,51 @@ struct WhatsNewFeedView: View {
                 }
             }
         }
+        .overlay {
+            if viewModel.items.isEmpty {
+                WhatsNewFeedUnavailableView(state: viewModel.state) {
+                    Task { await viewModel.retry() }
+                }
+            }
+        }
         .background(theme.primaryUi02.ignoresSafeArea())
         .task { await viewModel.load() }
+    }
+}
+
+/// What the feed shows while it has no rows: progress, an empty feed, or a failure to retry.
+private struct WhatsNewFeedUnavailableView: View {
+    @EnvironmentObject private var theme: Theme
+
+    let state: WhatsNewFeedViewModel.State
+    let retry: () -> Void
+
+    var body: some View {
+        content
+            .foregroundStyle(theme.primaryText01, theme.primaryText02)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch state {
+        case .loading:
+            ContentUnavailableView {
+                ProgressView()
+            }
+        case .loaded:
+            ContentUnavailableView(L10n.whatsNewFeedEmptyTitle,
+                                   systemImage: "envelope",
+                                   description: Text(L10n.whatsNewFeedEmptyDescription))
+        case .failed:
+            ContentUnavailableView {
+                Label(L10n.whatsNewFeedUnableToLoad, systemImage: "wifi.exclamationmark")
+            } description: {
+                Text(L10n.checkInternetConnection)
+            } actions: {
+                Button(L10n.tryAgain, action: retry)
+                    .foregroundStyle(theme.primaryInteractive01)
+            }
+        }
     }
 }
 
@@ -184,9 +227,17 @@ private extension WhatsNewFeedViewModel {
     PCNavigationController(rootViewController: WhatsNewFeedViewController(viewModel: .mock))
 }
 
-struct WhatsNewFeedView_Previews: PreviewProvider {
-    static var previews: some View {
-        WhatsNewFeedView(viewModel: .mock)
-            .previewWithAllThemes()
-    }
+#Preview("Loading") {
+    WhatsNewFeedUnavailableView(state: .loading) {}
+        .previewFollowingAppearance()
+}
+
+#Preview("Empty") {
+    WhatsNewFeedView(viewModel: WhatsNewFeedViewModel(messages: []))
+        .previewFollowingAppearance()
+}
+
+#Preview("Failed") {
+    WhatsNewFeedUnavailableView(state: .failed) {}
+        .previewFollowingAppearance()
 }

--- a/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
@@ -28,7 +28,14 @@ struct WhatsNewFeedItem: Identifiable, Hashable {
 /// screen — or marks itself read on the way there.
 @MainActor
 final class WhatsNewFeedViewModel: ObservableObject {
+    enum State {
+        case loading
+        case loaded
+        case failed
+    }
+
     @Published private(set) var items: [WhatsNewFeedItem] = []
+    @Published private(set) var state: State
 
     /// Called with the message a tapped row belongs to.
     var onSelect: ((WhatsNewMessage) -> Void)?
@@ -40,18 +47,36 @@ final class WhatsNewFeedViewModel: ObservableObject {
     init(catalogTask: WhatsNewCatalogTask = WhatsNewCatalogTask()) {
         self.catalogTask = catalogTask
         readMessageIDs = []
+        state = .loading
     }
 
     init(messages: [WhatsNewMessage], readMessageIDs: Set<String> = []) {
         catalogTask = nil
         self.readMessageIDs = readMessageIDs
+        state = .loaded
         show(messages)
     }
 
     /// Fills the feed in from the published catalog, or from the cached copy when it can't be reached.
+    ///
+    /// Fails only when there's no cached copy to fall back to. A load cancelled by the feed going
+    /// away leaves the state as it was, so the next one picks up from there.
     func load() async {
-        guard let catalogTask, let catalog = try? await catalogTask.catalog() else { return }
-        show(catalog.messages)
+        guard let catalogTask else { return }
+        do {
+            let catalog = try await catalogTask.catalog()
+            show(catalog.messages)
+            state = .loaded
+        } catch {
+            guard !Task.isCancelled else { return }
+            state = .failed
+        }
+    }
+
+    /// Loads the catalog again after it failed, showing progress while it does.
+    func retry() async {
+        state = .loading
+        await load()
     }
 
     var hasUnreadItems: Bool {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3613,8 +3613,17 @@
 /* Title for the announcement screen that calls out new features. */
 "whats_new" = "What's New";
 
+/* Description shown on the What's New feed when no messages have been published yet. */
+"whats_new_feed_empty_description" = "New features, tips and announcements will show up here.";
+
+/* Title shown on the What's New feed when no messages have been published yet. */
+"whats_new_feed_empty_title" = "No messages yet";
+
 /* Navigation bar button on the What's New feed that marks every message in the list as read. */
 "whats_new_feed_read_all" = "Read all";
+
+/* Title shown on the What's New feed when its messages couldn't be loaded. */
+"whats_new_feed_unable_to_load" = "Unable to load What's New";
 
 /* VoiceOver label for a video in a What's New message that was published without a description of its own. */
 "whats_new_message_video" = "Video";


### PR DESCRIPTION
| 📘 Part of: What's New Messages |
|:---:|

Part of PCIOS-926

Gives the What's New feed something to show while it has no rows, using the standard `ContentUnavailableView`:

- **Loading**: a spinner while the catalog is fetched.
- **Empty**: "No messages yet" when the catalog has nothing this build can show.
- **Error**: "Unable to load What's New" with **Try Again** when the catalog can't be reached and there's no cached copy to fall back to. The copy and button follow Discover's no-network state.

The view model gains a `state` (`loading` / `loaded` / `failed`) and `retry()`. A load cancelled by leaving the screen doesn't flip to the error, so the next visit just tries again. The states sit in an overlay shown only while there are no rows, so the reload that runs when coming back from a message never swaps the list for a spinner or an error.

## To test

1. Delete and reinstall the app so there's no cached catalog.
2. Enable the `whatsNewFeed` flag and restart.
3. Turn on Airplane Mode and go to Profile → **What's New**. A spinner shows, then "Unable to load What's New" with **Try Again**.
4. Turn off Airplane Mode and tap **Try Again**. The spinner shows again, then the feed loads.
5. Open a message and go back. The list stays put with no spinner.
6. For the empty state, map the catalog response to `{"schemaVersion": 1, "messages": []}` (e.g. with Proxyman) and open the feed, or check the **Empty** preview in `WhatsNewFeedView.swift`.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
