### PR TITLE
Add WhatsNewManager to keep the catalog cached and refreshed

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalogCache.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalogCache.swift
@@ -2,7 +2,7 @@ import Foundation
 import PocketCastsUtils
 
 /// Keeps the last successfully fetched What's New catalog on disk so the feed works offline.
-public struct WhatsNewCatalogCache {
+public struct WhatsNewCatalogCache: Sendable {
     private let directory: URL
 
     public init(directory: URL = WhatsNewCatalogCache.defaultDirectory) {
@@ -15,6 +15,11 @@ public struct WhatsNewCatalogCache {
 
     public func data(forLocale locale: String) -> Data? {
         try? Data(contentsOf: fileURL(forLocale: locale))
+    }
+
+    /// When the cached catalog was last written, or `nil` when there's nothing cached.
+    public func modificationDate(forLocale locale: String) -> Date? {
+        try? fileURL(forLocale: locale).resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
     }
 
     public func save(_ data: Data, forLocale locale: String) {

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalogTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewCatalogTask.swift
@@ -2,7 +2,7 @@ import Foundation
 import PocketCastsUtils
 
 /// Fetches the What's New catalog published to the CDN, caching the last good copy on disk.
-public struct WhatsNewCatalogTask {
+public struct WhatsNewCatalogTask: Sendable {
     public enum WhatsNewCatalogError: Error {
         case requestFailed(statusCode: Int)
     }
@@ -27,25 +27,15 @@ public struct WhatsNewCatalogTask {
         Locale.current.language.languageCode?.identifier ?? fallbackLocale
     }
 
-    /// The catalog for the current locale, refreshed from the CDN.
-    ///
-    /// Falls back to the cached catalog when the request fails or returns something that can't be
-    /// decoded, and only rethrows when the refresh was cancelled or there's nothing cached to fall
-    /// back to.
-    public func catalog() async throws -> WhatsNewCatalog {
-        do {
-            return try await refresh()
-        } catch {
-            guard !error.isCancellation, let cached = cachedCatalog() else { throw error }
-            FileLog.shared.addMessage("What's New: catalog request failed: \(error.localizedDescription). Returning the cached catalog")
-            return cached
-        }
-    }
-
     /// The last catalog that was fetched successfully, read back from disk.
     public func cachedCatalog() -> WhatsNewCatalog? {
         guard let data = cache.data(forLocale: locale) else { return nil }
         return try? WhatsNewCatalog.decoder.decode(WhatsNewCatalog.self, from: data)
+    }
+
+    /// When the catalog on disk was last written, or `nil` when nothing has been cached yet.
+    public var cachedCatalogDate: Date? {
+        cache.modificationDate(forLocale: locale)
     }
 
     /// Fetches the catalog from the CDN, replacing the cached copy once it decodes.
@@ -79,11 +69,5 @@ public struct WhatsNewCatalogTask {
             throw WhatsNewCatalogError.requestFailed(statusCode: statusCode)
         }
         return data
-    }
-}
-
-private extension Error {
-    var isCancellation: Bool {
-        self is CancellationError || (self as? URLError)?.code == .cancelled
     }
 }

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
@@ -54,7 +54,7 @@ public final class WhatsNewManager: ObservableObject {
             catalog = cached
         }
 
-        guard DateUtil.hasEnoughTimePassed(since: await cachedCatalogDate(), time: refreshInterval) else { return }
+        guard catalog == nil || DateUtil.hasEnoughTimePassed(since: await cachedCatalogDate(), time: refreshInterval) else { return }
 
         do {
             catalog = try await task.refresh()

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
@@ -54,7 +54,8 @@ public final class WhatsNewManager: ObservableObject {
             catalog = cached
         }
 
-        guard catalog == nil || DateUtil.hasEnoughTimePassed(since: await cachedCatalogDate(), time: refreshInterval) else { return }
+        let cachedDate = await cachedCatalogDate()
+        guard catalog == nil || DateUtil.hasEnoughTimePassed(since: cachedDate, time: refreshInterval) else { return }
 
         do {
             catalog = try await task.refresh()

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
@@ -1,0 +1,75 @@
+import Foundation
+import PocketCastsUtils
+
+/// Keeps the What's New catalog in memory and up to date.
+///
+/// The catalog is one small file published for the whole platform, so the app works from the last
+/// copy it fetched rather than from a request: the feed opens on the messages it already has
+/// instead of a spinner, and anything deriving state from the feed — the unread dot on Profile —
+/// can answer without waiting on the network.
+///
+/// Refreshing is driven by the app becoming active, which covers a cold launch and every return
+/// from the background, and throttled by how old the copy on disk is. A timer would keep firing
+/// against a file that changes a few times a month, and refreshing only at launch would leave a
+/// user who never quits the app on whatever was published the day they installed it.
+@MainActor
+public final class WhatsNewManager: ObservableObject {
+    nonisolated public static let shared = WhatsNewManager()
+
+    /// The catalog the app is working from: the last copy fetched, read back from disk on the first
+    /// refresh of the session.
+    @Published public private(set) var catalog: WhatsNewCatalog?
+
+    /// How long a fetched catalog is treated as current before the next foreground replaces it.
+    nonisolated public static let refreshInterval: TimeInterval = 6.hours
+
+    nonisolated private let task: WhatsNewCatalogTask
+    private let refreshInterval: TimeInterval
+    private var refreshTask: Task<Void, Never>?
+
+    nonisolated public init(task: WhatsNewCatalogTask = WhatsNewCatalogTask(),
+                            refreshInterval: TimeInterval = WhatsNewManager.refreshInterval) {
+        self.task = task
+        self.refreshInterval = refreshInterval
+    }
+
+    /// Publishes the catalog the app already has, and fetches a new one when that copy has aged out.
+    ///
+    /// Meant to be called every time the app becomes active: overlapping calls share one request,
+    /// and the network is only reached once the cached copy is older than the refresh interval.
+    @discardableResult
+    public func refreshIfNeeded() -> Task<Void, Never> {
+        if let refreshTask { return refreshTask }
+
+        let refreshTask = Task { [weak self] in
+            await self?.performRefresh()
+            self?.refreshTask = nil
+        }
+        self.refreshTask = refreshTask
+        return refreshTask
+    }
+
+    private func performRefresh() async {
+        if catalog == nil, let cached = await cachedCatalog() {
+            catalog = cached
+        }
+
+        guard DateUtil.hasEnoughTimePassed(since: await cachedCatalogDate(), time: refreshInterval) else { return }
+
+        do {
+            catalog = try await task.refresh()
+        } catch {
+            FileLog.shared.addMessage("What's New: failed to refresh the catalog: \(error.localizedDescription)")
+        }
+    }
+
+    /// Reads the cached catalog off the main thread, so a refresh on becoming active doesn't decode
+    /// it while the app is drawing its first frame.
+    nonisolated private func cachedCatalog() async -> WhatsNewCatalog? {
+        task.cachedCatalog()
+    }
+
+    nonisolated private func cachedCatalogDate() async -> Date? {
+        task.cachedCatalogDate
+    }
+}

--- a/Modules/Tests/PocketCastsServerTests/StubURLProtocol.swift
+++ b/Modules/Tests/PocketCastsServerTests/StubURLProtocol.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Answers every request in the session it's installed on with whatever `requestHandler` returns.
+final class StubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    /// How many requests have reached the stub since it was last reset.
+    nonisolated(unsafe) static var requestCount = 0
+
+    static func reset() {
+        requestHandler = nil
+        requestCount = 0
+    }
+
+    /// A session that goes nowhere but `requestHandler`.
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.requestCount += 1
+
+        guard let requestHandler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (response, data) = try requestHandler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewCatalogTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewCatalogTests.swift
@@ -78,7 +78,7 @@ final class WhatsNewCatalogTests: XCTestCase {
     """
 
     override func tearDown() {
-        StubURLProtocol.requestHandler = nil
+        StubURLProtocol.reset()
         super.tearDown()
     }
 
@@ -252,23 +252,44 @@ final class WhatsNewCatalogTests: XCTestCase {
         XCTAssertTrue(targeting.targets(.patron))
     }
 
-    func testCatalogFallsBackToTheCachedCopyWhenTheRequestFails() async throws {
-        let task = WhatsNewCatalogTask(session: stubbedSession(), cache: temporaryCache(), locale: "en")
+    func testASuccessfulRefreshIsReadableBackFromDisk() async throws {
+        let task = WhatsNewCatalogTask(session: StubURLProtocol.session(), cache: temporaryCache(), locale: "en")
+        XCTAssertNil(task.cachedCatalog())
+        XCTAssertNil(task.cachedCatalogDate)
 
         StubURLProtocol.requestHandler = { [json] request in
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             return (response, Data(json.utf8))
         }
-        let fetched = try await task.catalog()
-        XCTAssertEqual(fetched.messages.count, 2)
+        let fetched = try await task.refresh()
+
+        XCTAssertEqual(task.cachedCatalog()?.messages.map(\.id), fetched.messages.map(\.id))
+        XCTAssertEqual(try XCTUnwrap(task.cachedCatalogDate).timeIntervalSinceNow, 0, accuracy: 5,
+                       "The cache is dated when it's written, which is what decides the next refresh")
+    }
+
+    func testAFailedRefreshLeavesTheCachedCopyAlone() async throws {
+        let task = WhatsNewCatalogTask(session: StubURLProtocol.session(), cache: temporaryCache(), locale: "en")
+
+        StubURLProtocol.requestHandler = { [json] request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(json.utf8))
+        }
+        let fetched = try await task.refresh()
 
         StubURLProtocol.requestHandler = { _ in throw URLError(.notConnectedToInternet) }
-        let cached = try await task.catalog()
-        XCTAssertEqual(cached.messages.map(\.id), fetched.messages.map(\.id))
+        do {
+            _ = try await task.refresh()
+            XCTFail("Expected the request to fail")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .notConnectedToInternet)
+        }
+
+        XCTAssertEqual(task.cachedCatalog()?.messages.map(\.id), fetched.messages.map(\.id))
     }
 
     func testRefreshFallsBackToEnglishWhenTheLocaleIsNotPublished() async throws {
-        let task = WhatsNewCatalogTask(session: stubbedSession(), cache: temporaryCache(), locale: "pt")
+        let task = WhatsNewCatalogTask(session: StubURLProtocol.session(), cache: temporaryCache(), locale: "pt")
 
         var requestedPaths: [String] = []
         StubURLProtocol.requestHandler = { [json] request in
@@ -287,37 +308,7 @@ final class WhatsNewCatalogTests: XCTestCase {
         XCTAssertEqual(task.cachedCatalog()?.messages.count, 2, "The fallback catalog is cached for the requested locale")
     }
 
-    func testCatalogRethrowsCancellationRatherThanReturningTheCachedCopy() async throws {
-        let task = WhatsNewCatalogTask(session: stubbedSession(), cache: temporaryCache(), locale: "en")
-
-        StubURLProtocol.requestHandler = { [json] request in
-            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
-            return (response, Data(json.utf8))
-        }
-        _ = try await task.catalog()
-
-        StubURLProtocol.requestHandler = { _ in throw URLError(.cancelled) }
-
-        do {
-            _ = try await task.catalog()
-            XCTFail("Expected the cancelled request to propagate")
-        } catch {
-            XCTAssertEqual((error as? URLError)?.code, .cancelled)
-        }
-    }
-
-    func testCatalogThrowsWhenTheRequestFailsAndNothingIsCached() async {
-        let task = WhatsNewCatalogTask(session: stubbedSession(), cache: temporaryCache(), locale: "en")
-
-        StubURLProtocol.requestHandler = { _ in throw URLError(.notConnectedToInternet) }
-
-        do {
-            _ = try await task.catalog()
-            XCTFail("Expected the request to fail")
-        } catch {
-            XCTAssertEqual((error as? URLError)?.code, .notConnectedToInternet)
-        }
-    }
+    // MARK: - Helpers
 
     private func decodedTargeting(_ json: String) throws -> WhatsNewTargeting {
         try WhatsNewCatalog.decoder.decode(WhatsNewTargeting.self, from: Data(json.utf8))
@@ -327,12 +318,6 @@ final class WhatsNewCatalogTests: XCTestCase {
         try WhatsNewCatalog.decoder.decode(WhatsNewCatalog.self, from: Data(json.utf8))
     }
 
-    private func stubbedSession() -> URLSession {
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [StubURLProtocol.self]
-        return URLSession(configuration: configuration)
-    }
-
     private func temporaryCache() -> WhatsNewCatalogCache {
         let directory = URL.temporaryDirectory.appending(path: "whats-new-tests-\(UUID().uuidString)", directoryHint: .isDirectory)
         addTeardownBlock {
@@ -340,34 +325,4 @@ final class WhatsNewCatalogTests: XCTestCase {
         }
         return WhatsNewCatalogCache(directory: directory)
     }
-}
-
-private final class StubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
-
-    override class func canInit(with request: URLRequest) -> Bool {
-        true
-    }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        request
-    }
-
-    override func startLoading() {
-        guard let requestHandler = Self.requestHandler else {
-            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
-            return
-        }
-
-        do {
-            let (response, data) = try requestHandler(request)
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: data)
-            client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            client?.urlProtocol(self, didFailWithError: error)
-        }
-    }
-
-    override func stopLoading() {}
 }

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewManagerTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewManagerTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import PocketCastsUtils
+@testable import PocketCastsServer
+import XCTest
+
+@MainActor
+final class WhatsNewManagerTests: XCTestCase {
+    private let json = """
+    {
+      "schemaVersion": 1,
+      "messages": [
+        {
+          "id": "01K2Y08DAWG9N7XJZX5QTH9Z0K",
+          "type": "tip",
+          "publishedAt": "2026-08-17T08:00:00Z",
+          "targeting": {},
+          "summary": { "title": "Sort your Up Next" },
+          "content": { "pages": [{ "blocks": [{ "type": "paragraph", "content": "…" }] }] }
+        }
+      ]
+    }
+    """
+
+    override func tearDown() {
+        StubURLProtocol.reset()
+        super.tearDown()
+    }
+
+    func testFetchesTheCatalogWhenThereIsNothingOnDisk() async {
+        let manager = manager(cache: temporaryCache())
+        XCTAssertNil(manager.catalog)
+
+        await manager.refreshIfNeeded().value
+
+        XCTAssertEqual(manager.catalog?.messages.map(\.summary.title), ["Sort your Up Next"])
+    }
+
+    /// The feed and the unread state read the catalog straight off the manager, so it has to hold
+    /// what the last session fetched before anything reaches the network.
+    func testPublishesTheCatalogOnDiskWithoutGoingToTheNetwork() async {
+        let cache = temporaryCache()
+        cache.save(Data(json.utf8), forLocale: WhatsNewCatalogTask.currentLocale)
+
+        let manager = manager(cache: cache)
+        StubURLProtocol.requestHandler = { _ in
+            XCTFail("A catalog written moments ago shouldn't be fetched again")
+            throw URLError(.unknown)
+        }
+
+        await manager.refreshIfNeeded().value
+
+        XCTAssertEqual(manager.catalog?.messages.map(\.summary.title), ["Sort your Up Next"])
+    }
+
+    func testDoesNotFetchAgainWhileTheCopyOnDiskIsCurrent() async {
+        let manager = manager(cache: temporaryCache())
+
+        await manager.refreshIfNeeded().value
+        await manager.refreshIfNeeded().value
+
+        XCTAssertEqual(requestCount, 1, "Becoming active again inside the interval doesn't re-fetch the catalog")
+    }
+
+    func testFetchesAgainOnceTheCopyOnDiskHasAgedOut() async {
+        let manager = manager(cache: temporaryCache(), refreshInterval: 0)
+
+        await manager.refreshIfNeeded().value
+        await manager.refreshIfNeeded().value
+
+        XCTAssertEqual(requestCount, 2)
+    }
+
+    func testOverlappingRefreshesShareOneRequest() async {
+        let manager = manager(cache: temporaryCache(), refreshInterval: 0)
+
+        let first = manager.refreshIfNeeded()
+        let second = manager.refreshIfNeeded()
+        await first.value
+        await second.value
+
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    /// Offline, the feed still has to show what it had rather than emptying itself out.
+    func testKeepsTheCatalogItHasWhenTheRefreshFails() async {
+        let manager = manager(cache: temporaryCache(), refreshInterval: 0)
+        await manager.refreshIfNeeded().value
+
+        StubURLProtocol.requestHandler = { _ in throw URLError(.notConnectedToInternet) }
+        await manager.refreshIfNeeded().value
+
+        XCTAssertEqual(manager.catalog?.messages.map(\.summary.title), ["Sort your Up Next"])
+    }
+
+    // MARK: - Helpers
+
+    private var requestCount: Int { StubURLProtocol.requestCount }
+
+    private func manager(cache: WhatsNewCatalogCache,
+                         refreshInterval: TimeInterval = WhatsNewManager.refreshInterval) -> WhatsNewManager {
+        StubURLProtocol.requestHandler = { [json] request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(json.utf8))
+        }
+
+        let task = WhatsNewCatalogTask(session: StubURLProtocol.session(), cache: cache)
+        return WhatsNewManager(task: task, refreshInterval: refreshInterval)
+    }
+
+    private func temporaryCache() -> WhatsNewCatalogCache {
+        let directory = URL.temporaryDirectory.appending(path: "whats-new-tests-\(UUID().uuidString)", directoryHint: .isDirectory)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return WhatsNewCatalogCache(directory: directory)
+    }
+}

--- a/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
@@ -137,7 +137,7 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
 
     /// The Profile row hands over an empty feed, so nothing shows until the catalog arrives.
     func testLoadingFillsTheFeedFromTheCatalog() async {
-        let viewModel = WhatsNewFeedViewModel(catalogTask: catalogTask(publishing: Self.catalogJSON), targeting: targeting)
+        let viewModel = WhatsNewFeedViewModel(manager: manager(publishing: Self.catalogJSON), targeting: targeting)
         XCTAssertTrue(viewModel.items.isEmpty)
         XCTAssertEqual(viewModel.state, .loading)
 
@@ -149,7 +149,7 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
 
     /// With no cached copy to fall back to, a catalog that can't be reached is a failure, not an empty feed.
     func testFailingToReachTheCatalogWithNothingCachedFails() async {
-        let viewModel = WhatsNewFeedViewModel(catalogTask: catalogTask())
+        let viewModel = WhatsNewFeedViewModel(manager: manager())
 
         await viewModel.load()
 
@@ -158,7 +158,7 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
     }
 
     func testRetryingFillsTheFeedOnceTheCatalogCanBeReached() async {
-        let viewModel = WhatsNewFeedViewModel(catalogTask: catalogTask())
+        let viewModel = WhatsNewFeedViewModel(manager: manager())
         await viewModel.load()
         publish(Self.catalogJSON)
 
@@ -170,7 +170,7 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
 
     /// Reads live in memory until read-state sync lands, so a refresh must not undo them.
     func testReloadingTheCatalogKeepsWhatWasRead() async throws {
-        let viewModel = WhatsNewFeedViewModel(catalogTask: catalogTask(publishing: Self.catalogJSON), targeting: targeting)
+        let viewModel = WhatsNewFeedViewModel(manager: manager(publishing: Self.catalogJSON), targeting: targeting)
         await viewModel.load()
         viewModel.select(try XCTUnwrap(viewModel.items.first))
 
@@ -202,8 +202,8 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
         return try decoder.decode(WhatsNewCatalog.self, from: Data(json.utf8)).messages
     }
 
-    /// A catalog task that answers with `json`, or fails every request until something is published.
-    private func catalogTask(publishing json: String? = nil) -> WhatsNewCatalogTask {
+    /// A manager whose catalog answers with `json`, or fails every request until something is published.
+    private func manager(publishing json: String? = nil) -> WhatsNewManager {
         if let json {
             publish(json)
         }
@@ -216,8 +216,9 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
             try? FileManager.default.removeItem(at: directory)
         }
 
-        return WhatsNewCatalogTask(session: URLSession(configuration: configuration),
-                                   cache: WhatsNewCatalogCache(directory: directory))
+        let task = WhatsNewCatalogTask(session: URLSession(configuration: configuration),
+                                       cache: WhatsNewCatalogCache(directory: directory))
+        return WhatsNewManager(task: task)
     }
 
     private func publish(_ json: String) {

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -158,6 +158,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupSignOutListener()
         appLifecycleAnalytics.didBecomeActive()
 
+        if FeatureFlag.whatsNewFeed.enabled {
+            WhatsNewManager.shared.refreshIfNeeded()
+        }
+
         // give the network a few seconds to come up before refreshing, also only refresh if the last refresh was more than 5 minutes ago
         let lastUpdateTime = ServerSettings.lastRefreshEndTime()
         if DateUtil.hasEnoughTimePassed(since: lastUpdateTime, time: AppDelegate.minTimeBetweenRefreshes) {

--- a/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
@@ -42,38 +42,41 @@ final class WhatsNewFeedViewModel: ObservableObject {
 
     private var messages: [WhatsNewMessage] = []
     private var readMessageIDs: Set<String>
-    private let catalogTask: WhatsNewCatalogTask?
+    private let manager: WhatsNewManager?
     private let targeting: WhatsNewMessageFilter
 
-    init(catalogTask: WhatsNewCatalogTask = WhatsNewCatalogTask(), targeting: WhatsNewMessageFilter = .current) {
-        self.catalogTask = catalogTask
+    init(manager: WhatsNewManager = .shared, targeting: WhatsNewMessageFilter = .current) {
+        self.manager = manager
         self.targeting = targeting
         readMessageIDs = []
-        state = .loading
+        state = manager.catalog == nil ? .loading : .loaded
+        show(manager.catalog?.messages ?? [])
     }
 
     init(messages: [WhatsNewMessage], readMessageIDs: Set<String> = [], targeting: WhatsNewMessageFilter = .current) {
-        catalogTask = nil
+        manager = nil
         self.targeting = targeting
         self.readMessageIDs = readMessageIDs
         state = .loaded
         show(messages)
     }
 
-    /// Fills the feed in from the published catalog, or from the cached copy when it can't be reached.
+    /// Shows what the manager has, waiting on the refresh it starts when that copy has aged out.
     ///
-    /// Fails only when there's no cached copy to fall back to. A load cancelled by the feed going
-    /// away leaves the state as it was, so the next one picks up from there.
+    /// Fails only when the manager has no catalog at all: a refresh that fails over a cached copy
+    /// still has messages to show. A load cancelled by the feed going away leaves the state as it
+    /// was, so the next one picks up from there.
     func load() async {
-        guard let catalogTask else { return }
-        do {
-            let catalog = try await catalogTask.catalog()
-            show(catalog.messages)
-            state = .loaded
-        } catch {
-            guard !Task.isCancelled else { return }
+        guard let manager else { return }
+        await manager.refreshIfNeeded().value
+
+        guard !Task.isCancelled else { return }
+        guard let catalog = manager.catalog else {
             state = .failed
+            return
         }
+        show(catalog.messages)
+        state = .loaded
     }
 
     /// Loads the catalog again after it failed, showing progress while it does.


### PR DESCRIPTION
| 📘 Part of: What's New Messages |
|:---:|

Part of PCIOS-926

Adds `WhatsNewManager`, the shared front door to the What's New catalog. It holds the catalog in memory, keeps the last fetched copy on disk, and refreshes when the app becomes active — which covers a cold launch and every return from the background — throttled to once every 6 hours by the age of the cached file. A timer would keep firing against a file that changes a few times a month, and refreshing only at launch would strand a user who never quits the app.

The feed now opens on what the manager already has instead of a spinner, and a failed refresh keeps the cached messages rather than emptying the list. `WhatsNewCatalogTask.catalog()` is gone: the manager holds the cached copy, so falling back to disk on failure was redundant.

## To test

1. Enable the `whatsNewFeed` flag and restart.
2. Go to Profile → **What's New**. The feed loads.
3. Background the app and return to it. Within 6 hours of the last fetch, no new request goes out (check with Proxyman).
4. Turn on Airplane Mode, kill the app, relaunch, and open the feed. The messages from step 2 still show, read from disk.
5. Delete and reinstall, then open the feed in Airplane Mode. "Unable to load What's New" with **Try Again**, since there's nothing cached.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
