### PR TITLE
Add pull-to-refresh to the What's New feed

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
@@ -26,6 +26,7 @@ public final class WhatsNewManager: ObservableObject {
     nonisolated private let task: WhatsNewCatalogTask
     private let refreshInterval: TimeInterval
     private var refreshTask: Task<Void, Never>?
+    private var isRefreshForced = false
 
     nonisolated public init(task: WhatsNewCatalogTask = WhatsNewCatalogTask(),
                             refreshInterval: TimeInterval = WhatsNewManager.refreshInterval) {
@@ -44,9 +45,20 @@ public final class WhatsNewManager: ObservableObject {
         let refreshTask = Task { [weak self] in
             await self?.performRefresh()
             self?.refreshTask = nil
+            self?.isRefreshForced = false
         }
         self.refreshTask = refreshTask
         return refreshTask
+    }
+
+    /// Fetches the catalog however recently the copy on disk was written, for when the user asks
+    /// for the latest messages, such as by pulling to refresh the feed.
+    ///
+    /// Joins a refresh already in flight, making sure it reaches the network.
+    @discardableResult
+    public func refresh() -> Task<Void, Never> {
+        isRefreshForced = true
+        return refreshIfNeeded()
     }
 
     private func performRefresh() async {
@@ -54,8 +66,8 @@ public final class WhatsNewManager: ObservableObject {
             catalog = cached
         }
 
-        let cachedDate = await cachedCatalogDate()
-        guard catalog == nil || DateUtil.hasEnoughTimePassed(since: cachedDate, time: refreshInterval) else { return }
+        let isStale = DateUtil.hasEnoughTimePassed(since: await cachedCatalogDate(), time: refreshInterval)
+        guard catalog == nil || isStale || isRefreshForced else { return }
 
         do {
             catalog = try await task.refresh()

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewManagerTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewManagerTests.swift
@@ -87,6 +87,39 @@ final class WhatsNewManagerTests: XCTestCase {
         XCTAssertEqual(requestCount, 1)
     }
 
+    /// Pulling to refresh the feed asks for the latest messages, however recently they were fetched.
+    func testRefreshingFetchesWhileTheCopyOnDiskIsCurrent() async {
+        let manager = manager(cache: temporaryCache())
+        await manager.refreshIfNeeded().value
+
+        await manager.refresh().value
+
+        XCTAssertEqual(requestCount, 2)
+    }
+
+    /// The refresh already in flight may be about to find the copy on disk current and stop there.
+    func testRefreshingJoinsTheRefreshInFlightAndStillFetches() async {
+        let cache = temporaryCache()
+        cache.save(Data(json.utf8), forLocale: WhatsNewCatalogTask.currentLocale)
+        let manager = manager(cache: cache)
+
+        let first = manager.refreshIfNeeded()
+        let second = manager.refresh()
+        await first.value
+        await second.value
+
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    func testRefreshingDoesNotForceTheNextRefresh() async {
+        let manager = manager(cache: temporaryCache())
+        await manager.refresh().value
+
+        await manager.refreshIfNeeded().value
+
+        XCTAssertEqual(requestCount, 1)
+    }
+
     /// Offline, the feed still has to show what it had rather than emptying itself out.
     func testKeepsTheCatalogItHasWhenTheRefreshFails() async {
         let manager = manager(cache: temporaryCache(), refreshInterval: 0)

--- a/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
@@ -157,6 +157,34 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.items.map(\.title), ["Sort your Up Next"])
     }
 
+    /// Pulling to refresh doesn't wait for the copy the feed opened on to age out.
+    func testRefreshingShowsWhatWasPublishedSinceTheFeedLoaded() async {
+        let viewModel = WhatsNewFeedViewModel(manager: manager(publishing: Self.catalogJSON), targeting: targeting)
+        await viewModel.load()
+        publish("""
+        {
+          "schemaVersion": 1,
+          "messages": [
+            \(Self.tip(id: "550e8400-e29b-41d4-a716-446655440001",
+                       title: "Sort your Up Next",
+                       publishedAt: "2026-08-17T08:00:00Z")),
+            {
+              "id": "550e8400-e29b-41d4-a716-446655440002",
+              "type": "new_feature",
+              "publishedAt": "2026-08-18T08:00:00Z",
+              "targeting": { "audiences": [] },
+              "title": "Folders for everyone",
+              "pages": [\(Self.page)]
+            }
+          ]
+        }
+        """)
+
+        await viewModel.refresh()
+
+        XCTAssertEqual(viewModel.items.map(\.title), ["Folders for everyone", "Sort your Up Next"])
+    }
+
     /// Reads live in memory until read-state sync lands, so a refresh must not undo them.
     func testReloadingTheCatalogKeepsWhatWasRead() async throws {
         let viewModel = WhatsNewFeedViewModel(manager: manager(publishing: Self.catalogJSON), targeting: targeting)

--- a/podcasts/Whats New/Feed/WhatsNewFeedView.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedView.swift
@@ -27,6 +27,7 @@ struct WhatsNewFeedView: View {
                 }
             }
         }
+        .refreshable { await viewModel.refresh() }
         .overlay {
             if viewModel.items.isEmpty {
                 WhatsNewFeedUnavailableView(state: viewModel.state) {

--- a/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
@@ -74,14 +74,14 @@ final class WhatsNewFeedViewModel: ObservableObject {
     func load() async {
         guard let manager else { return }
         await manager.refreshIfNeeded().value
+        showCatalog(of: manager)
+    }
 
-        guard !Task.isCancelled else { return }
-        guard let catalog = manager.catalog else {
-            state = .failed
-            return
-        }
-        show(catalog.messages)
-        state = .loaded
+    /// Fetches the catalog again however recently it was fetched, for pulling to refresh the feed.
+    func refresh() async {
+        guard let manager else { return }
+        await manager.refresh().value
+        showCatalog(of: manager)
     }
 
     /// Loads the catalog again after it failed, showing progress while it does.
@@ -126,6 +126,16 @@ final class WhatsNewFeedViewModel: ObservableObject {
 
         guard let index = items.firstIndex(where: { $0.id == id }) else { return }
         items[index].isUnread = false
+    }
+
+    private func showCatalog(of manager: WhatsNewManager) {
+        guard !Task.isCancelled else { return }
+        guard let catalog = manager.catalog else {
+            state = .failed
+            return
+        }
+        show(catalog.messages)
+        state = .loaded
     }
 
     private func show(_ messages: [WhatsNewMessage]) {


### PR DESCRIPTION
| 📘 Part of: What's New Messages |
|:---:|

Part of PCIOS-926

Adds pull-to-refresh to the What's New feed. Pulling calls the new `WhatsNewManager.refresh()`, which fetches the catalog however recently the copy on disk was written, bypassing the 6-hour throttle `refreshIfNeeded()` applies.

If a refresh is already in flight (the feed opening, or the app becoming active), `refresh()` joins it instead of sending a second request, and marks it forced so it still reaches the network even if it was about to find the cached copy current. The staleness check reads the file date before looking at the flag, so a pull that lands while that read is suspended is still honored. The flag is cleared when the refresh finishes, so a pull doesn't force the next foreground refresh.

## To test

1. Enable the `whatsNewFeed` flag and restart.
2. Go to Profile → **What's New**. The feed loads.
3. Go back and open the feed again. No new request goes out (check with Proxyman).
4. Pull down on the feed. A request for the catalog goes out and the spinner goes away once it completes.
5. Background the app and return to it. No request goes out: the pull restarted the 6-hour window.
6. Turn on Airplane Mode and pull to refresh. The spinner goes away and the messages stay.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
