### PR TITLE
Only show the What's New artwork fallback while there's no image

### DIFF
--- a/podcasts/Whats New/Feed/WhatsNewFeedView.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedView.swift
@@ -130,29 +130,39 @@ private struct WhatsNewFeedRow: View {
     }
 }
 
-/// The artwork the CDN published for a message, over a fallback the message's type picks.
+/// The artwork the CDN published for a message, or a fallback the message's type picks while there's none to show.
 private struct WhatsNewFeedArtworkView: View {
     let item: WhatsNewFeedItem
 
     var body: some View {
+        artwork
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+    }
+
+    @ViewBuilder
+    private var artwork: some View {
+        if let imageURL = item.imageURL {
+            KFImage(imageURL)
+                .placeholder { fallback }
+                .targetCache(ImageManager.sharedManager.discoverCache)
+                .fade(duration: 0.25)
+                .resizable()
+                .scaledToFill()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .clipped()
+        } else {
+            fallback
+        }
+    }
+
+    private var fallback: some View {
         ZStack {
             LinearGradient(colors: item.type.artworkGradient, startPoint: .topLeading, endPoint: .bottomTrailing)
 
             Image(systemName: item.type.artworkSymbolName)
                 .font(.system(size: 22, weight: .semibold))
                 .foregroundStyle(.white)
-
-            if let imageURL = item.imageURL {
-                KFImage(imageURL)
-                    .targetCache(ImageManager.sharedManager.discoverCache)
-                    .fade(duration: 0.25)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .clipped()
-            }
         }
-        .clipShape(RoundedRectangle(cornerRadius: 4))
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: What's New Messages |
|:---:|

Part of PCIOS-926

The feed row drew the message type's gradient and symbol under every artwork, so they showed through any published image that isn't fully opaque, along its edges, and while it faded in.

The fallback is now the `KFImage` placeholder instead: it shows while the image loads or if it fails, and goes away once the image is on screen. Messages with no image still get the fallback.

## To test

1. Enable the `whatsNewFeed` flag and restart.
2. Go to Profile → **What's New**.
3. A message with an image shows only the image, with no gradient or symbol behind it or around its edges, including as it fades in. The **Feed in a navigation controller** preview in `WhatsNewFeedView.swift` has one too.
4. Messages without an image still show the gradient and symbol.
5. Block the image host (e.g. with Proxyman) and clear the app's cache. The message with an image falls back to the gradient and symbol.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
