### PR TITLE
Remember read What's New messages and show unread dots on Profile

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PocketCastsUtils
 
-/// Keeps the What's New catalog in memory and up to date.
+/// Keeps the What's New catalog in memory and up to date, along with what the user has read of it.
 ///
 /// The catalog is one small file published for the whole platform, so the app works from the last
 /// copy it fetched rather than from a request: the feed opens on the messages it already has
@@ -12,6 +12,10 @@ import PocketCastsUtils
 /// from the background, and throttled by how old the copy on disk is. A timer would keep firing
 /// against a file that changes a few times a month, and refreshing only at launch would leave a
 /// user who never quits the app on whatever was published the day they installed it.
+///
+/// Read state is kept in a file next to the catalog until it syncs with the server, and is read
+/// back before the first catalog is published, so a message read in an earlier session never shows
+/// up unread, even for a moment.
 @MainActor
 public final class WhatsNewManager: ObservableObject {
     nonisolated public static let shared = WhatsNewManager()
@@ -20,17 +24,24 @@ public final class WhatsNewManager: ObservableObject {
     /// refresh of the session.
     @Published public private(set) var catalog: WhatsNewCatalog?
 
+    /// Which messages the user has read, and which the Profile tab has already pointed them at.
+    @Published public private(set) var readState = WhatsNewReadState()
+
     /// How long a fetched catalog is treated as current before the next foreground replaces it.
     nonisolated public static let refreshInterval: TimeInterval = 6.hours
 
     nonisolated private let task: WhatsNewCatalogTask
+    nonisolated private let readStateStore: WhatsNewReadStateStore
     private let refreshInterval: TimeInterval
     private var refreshTask: Task<Void, Never>?
     private var isRefreshForced = false
+    private var hasLoadedReadState = false
 
     nonisolated public init(task: WhatsNewCatalogTask = WhatsNewCatalogTask(),
+                            readStateStore: WhatsNewReadStateStore = WhatsNewReadStateStore(),
                             refreshInterval: TimeInterval = WhatsNewManager.refreshInterval) {
         self.task = task
+        self.readStateStore = readStateStore
         self.refreshInterval = refreshInterval
     }
 
@@ -61,7 +72,27 @@ public final class WhatsNewManager: ObservableObject {
         return refreshIfNeeded()
     }
 
+    /// Marks messages read, whether the user opened one or cleared the feed with "Read all".
+    public func markAsRead(_ messageIDs: some Sequence<String>) {
+        updateReadState { $0.readMessageIDs.formUnion(messageIDs) }
+    }
+
+    /// Records that the Profile tab has pointed the user at the messages, so its dot stays off until
+    /// a message arrives that it hasn't.
+    public func markAsSeen(_ messageIDs: some Sequence<String>) {
+        updateReadState { $0.seenMessageIDs.formUnion(messageIDs) }
+    }
+
+    /// Forgets every message read or seen, bringing back each unread indicator.
+    public func resetReadState() {
+        hasLoadedReadState = true
+        readState = WhatsNewReadState()
+        readStateStore.save(readState)
+    }
+
     private func performRefresh() async {
+        await loadReadStateIfNeeded()
+
         if catalog == nil, let cached = await cachedCatalog() {
             catalog = cached
         }
@@ -76,6 +107,37 @@ public final class WhatsNewManager: ObservableObject {
         }
     }
 
+    /// Saves a change to the read state once the copy on disk has been read back, since saving
+    /// before then would overwrite it. The load saves the two merged instead.
+    private func updateReadState(_ update: (inout WhatsNewReadState) -> Void) {
+        var readState = self.readState
+        update(&readState)
+        guard readState != self.readState else { return }
+
+        self.readState = readState
+        if hasLoadedReadState {
+            readStateStore.save(readState)
+        }
+    }
+
+    /// Reads back the state saved in an earlier session, keeping anything marked since launch.
+    ///
+    /// A reset made while the file is being read wins over what was in it.
+    private func loadReadStateIfNeeded() async {
+        guard !hasLoadedReadState else { return }
+        let stored = await storedReadState()
+        guard !hasLoadedReadState else { return }
+        hasLoadedReadState = true
+
+        let merged = stored.merging(readState)
+        if merged != readState {
+            readState = merged
+        }
+        if merged != stored {
+            readStateStore.save(merged)
+        }
+    }
+
     /// Reads the cached catalog off the main thread, so a refresh on becoming active doesn't decode
     /// it while the app is drawing its first frame.
     nonisolated private func cachedCatalog() async -> WhatsNewCatalog? {
@@ -84,5 +146,9 @@ public final class WhatsNewManager: ObservableObject {
 
     nonisolated private func cachedCatalogDate() async -> Date? {
         task.cachedCatalogDate
+    }
+
+    nonisolated private func storedReadState() async -> WhatsNewReadState {
+        readStateStore.load()
     }
 }

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
@@ -13,9 +13,9 @@ import PocketCastsUtils
 /// against a file that changes a few times a month, and refreshing only at launch would leave a
 /// user who never quits the app on whatever was published the day they installed it.
 ///
-/// Read state is kept in a file next to the catalog until it syncs with the server, and is read
-/// back before the first catalog is published, so a message read in an earlier session never shows
-/// up unread, even for a moment.
+/// Read state is kept in a file until it syncs with the server, and is read back before the first
+/// catalog is published, so a message read in an earlier session never shows up unread, even for a
+/// moment.
 @MainActor
 public final class WhatsNewManager: ObservableObject {
     nonisolated public static let shared = WhatsNewManager()

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
@@ -24,8 +24,8 @@ public final class WhatsNewManager: ObservableObject {
     /// refresh of the session.
     @Published public private(set) var catalog: WhatsNewCatalog?
 
-    /// Which messages the user has read, and which the feed and the Profile tab have already pointed
-    /// them at.
+    /// Which messages the user has read, which the feed and the Profile tab have already pointed
+    /// them at, and which polls the user answered.
     @Published public private(set) var readState = WhatsNewReadState()
 
     /// How long a fetched catalog is treated as current before the next foreground replaces it.
@@ -94,7 +94,13 @@ public final class WhatsNewManager: ObservableObject {
         }
     }
 
-    /// Forgets every message read, seen or listed, bringing back each indicator.
+    /// Records that the user answered a research poll, which keeps it closed from then on.
+    public func markAsResponded(toPoll pollID: String) {
+        updateReadState { $0.respondedPollIDs.insert(pollID) }
+    }
+
+    /// Forgets every message read, seen or listed and every poll answered, bringing back each
+    /// indicator and reopening each poll.
     public func resetReadState() {
         hasLoadedReadState = true
         readState = WhatsNewReadState()

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewManager.swift
@@ -5,7 +5,7 @@ import PocketCastsUtils
 ///
 /// The catalog is one small file published for the whole platform, so the app works from the last
 /// copy it fetched rather than from a request: the feed opens on the messages it already has
-/// instead of a spinner, and anything deriving state from the feed — the unread dot on Profile —
+/// instead of a spinner, and anything deriving state from the feed — the dots on Profile —
 /// can answer without waiting on the network.
 ///
 /// Refreshing is driven by the app becoming active, which covers a cold launch and every return
@@ -24,7 +24,8 @@ public final class WhatsNewManager: ObservableObject {
     /// refresh of the session.
     @Published public private(set) var catalog: WhatsNewCatalog?
 
-    /// Which messages the user has read, and which the Profile tab has already pointed them at.
+    /// Which messages the user has read, and which the feed and the Profile tab have already pointed
+    /// them at.
     @Published public private(set) var readState = WhatsNewReadState()
 
     /// How long a fetched catalog is treated as current before the next foreground replaces it.
@@ -83,7 +84,17 @@ public final class WhatsNewManager: ObservableObject {
         updateReadState { $0.seenMessageIDs.formUnion(messageIDs) }
     }
 
-    /// Forgets every message read or seen, bringing back each unread indicator.
+    /// Records that the feed has listed the messages, so the dot on the What's New row stays off
+    /// until a message arrives that it hasn't. The Profile tab has nothing left to point at either.
+    public func markAsListed(_ messageIDs: some Sequence<String>) {
+        let messageIDs = Set(messageIDs)
+        updateReadState {
+            $0.listedMessageIDs.formUnion(messageIDs)
+            $0.seenMessageIDs.formUnion(messageIDs)
+        }
+    }
+
+    /// Forgets every message read, seen or listed, bringing back each indicator.
     public func resetReadState() {
         hasLoadedReadState = true
         readState = WhatsNewReadState()

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewReadState.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewReadState.swift
@@ -23,6 +23,13 @@ public struct WhatsNewReadState: Codable, Hashable, Sendable {
         self.listedMessageIDs = listedMessageIDs
     }
 
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        readMessageIDs = try container.decodeIfPresent(Set<String>.self, forKey: .readMessageIDs) ?? []
+        seenMessageIDs = try container.decodeIfPresent(Set<String>.self, forKey: .seenMessageIDs) ?? []
+        listedMessageIDs = try container.decodeIfPresent(Set<String>.self, forKey: .listedMessageIDs) ?? []
+    }
+
     public func isRead(_ messageID: String) -> Bool {
         readMessageIDs.contains(messageID)
     }

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewReadState.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewReadState.swift
@@ -3,19 +3,24 @@ import PocketCastsUtils
 
 /// What the user has done with the What's New messages, by message ID.
 ///
-/// Outside of a reset neither set ever shrinks — nothing marks a message unread again — so two
-/// copies of the state combine by keeping everything either one has.
+/// Outside of a reset no set ever shrinks — nothing marks a message unread again — so two copies of
+/// the state combine by keeping everything either one has.
 public struct WhatsNewReadState: Codable, Hashable, Sendable {
     /// Messages the user opened or cleared with "Read all".
     public var readMessageIDs: Set<String>
 
-    /// Messages that were in the feed the last time the user tapped the Profile tab, which the dot
-    /// on the tab has already pointed them at.
+    /// Messages that were in the feed when the user tapped the Profile tab or opened the feed, which
+    /// the dot on the tab has already pointed them at.
     public var seenMessageIDs: Set<String>
 
-    public init(readMessageIDs: Set<String> = [], seenMessageIDs: Set<String> = []) {
+    /// Messages the feed listed when the user opened it, which the dot on the What's New row has
+    /// already pointed them at.
+    public var listedMessageIDs: Set<String>
+
+    public init(readMessageIDs: Set<String> = [], seenMessageIDs: Set<String> = [], listedMessageIDs: Set<String> = []) {
         self.readMessageIDs = readMessageIDs
         self.seenMessageIDs = seenMessageIDs
+        self.listedMessageIDs = listedMessageIDs
     }
 
     public func isRead(_ messageID: String) -> Bool {
@@ -27,9 +32,15 @@ public struct WhatsNewReadState: Codable, Hashable, Sendable {
         !isRead(messageID) && !seenMessageIDs.contains(messageID)
     }
 
+    /// Whether the feed has listed the message, read or not.
+    public func isListed(_ messageID: String) -> Bool {
+        listedMessageIDs.contains(messageID)
+    }
+
     func merging(_ other: WhatsNewReadState) -> WhatsNewReadState {
         WhatsNewReadState(readMessageIDs: readMessageIDs.union(other.readMessageIDs),
-                          seenMessageIDs: seenMessageIDs.union(other.seenMessageIDs))
+                          seenMessageIDs: seenMessageIDs.union(other.seenMessageIDs),
+                          listedMessageIDs: listedMessageIDs.union(other.listedMessageIDs))
     }
 }
 

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewReadState.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewReadState.swift
@@ -44,15 +44,19 @@ public struct WhatsNewReadState: Codable, Hashable, Sendable {
     }
 }
 
-/// Keeps the What's New read state in a file next to the cached catalog.
+/// Keeps the What's New read state in a file.
 ///
 /// Read state is meant to sync across the user's devices through the server; until it does, this
 /// file is the only copy.
 public struct WhatsNewReadStateStore: Sendable {
     private let fileURL: URL
 
-    public init(directory: URL = WhatsNewCatalogCache.defaultDirectory) {
+    public init(directory: URL = WhatsNewReadStateStore.defaultDirectory) {
         fileURL = directory.appending(path: "read-state.json")
+    }
+
+    public static var defaultDirectory: URL {
+        URL.applicationSupportDirectory.appending(path: "whats-new", directoryHint: .isDirectory)
     }
 
     /// The state last saved, or an empty one when nothing has been saved or it can't be read back.

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewReadState.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewReadState.swift
@@ -9,8 +9,8 @@ public struct WhatsNewReadState: Codable, Hashable, Sendable {
     /// Messages the user opened or cleared with "Read all".
     public var readMessageIDs: Set<String>
 
-    /// Messages that were in the feed when the user tapped the Profile tab or opened the feed, which
-    /// the dot on the tab has already pointed them at.
+    /// Messages that were in the feed when the user went to Profile or opened the feed, which the
+    /// dot on the tab has already pointed them at.
     public var seenMessageIDs: Set<String>
 
     /// Messages the feed listed when the user opened it, which the dot on the What's New row has

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewReadState.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewReadState.swift
@@ -1,0 +1,66 @@
+import Foundation
+import PocketCastsUtils
+
+/// What the user has done with the What's New messages, by message ID.
+///
+/// Outside of a reset neither set ever shrinks — nothing marks a message unread again — so two
+/// copies of the state combine by keeping everything either one has.
+public struct WhatsNewReadState: Codable, Hashable, Sendable {
+    /// Messages the user opened or cleared with "Read all".
+    public var readMessageIDs: Set<String>
+
+    /// Messages that were in the feed the last time the user tapped the Profile tab, which the dot
+    /// on the tab has already pointed them at.
+    public var seenMessageIDs: Set<String>
+
+    public init(readMessageIDs: Set<String> = [], seenMessageIDs: Set<String> = []) {
+        self.readMessageIDs = readMessageIDs
+        self.seenMessageIDs = seenMessageIDs
+    }
+
+    public func isRead(_ messageID: String) -> Bool {
+        readMessageIDs.contains(messageID)
+    }
+
+    /// Whether the message is unread and the Profile tab hasn't pointed the user at it yet.
+    public func isUnseen(_ messageID: String) -> Bool {
+        !isRead(messageID) && !seenMessageIDs.contains(messageID)
+    }
+
+    func merging(_ other: WhatsNewReadState) -> WhatsNewReadState {
+        WhatsNewReadState(readMessageIDs: readMessageIDs.union(other.readMessageIDs),
+                          seenMessageIDs: seenMessageIDs.union(other.seenMessageIDs))
+    }
+}
+
+/// Keeps the What's New read state in a file next to the cached catalog.
+///
+/// Read state is meant to sync across the user's devices through the server; until it does, this
+/// file is the only copy.
+public struct WhatsNewReadStateStore: Sendable {
+    private let fileURL: URL
+
+    public init(directory: URL = WhatsNewCatalogCache.defaultDirectory) {
+        fileURL = directory.appending(path: "read-state.json")
+    }
+
+    /// The state last saved, or an empty one when nothing has been saved or it can't be read back.
+    public func load() -> WhatsNewReadState {
+        guard let data = try? Data(contentsOf: fileURL) else { return WhatsNewReadState() }
+        do {
+            return try JSONDecoder().decode(WhatsNewReadState.self, from: data)
+        } catch {
+            FileLog.shared.addMessage("What's New: failed to read the read state: \(error.localizedDescription)")
+            return WhatsNewReadState()
+        }
+    }
+
+    public func save(_ state: WhatsNewReadState) {
+        do {
+            try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try JSONEncoder().encode(state).write(to: fileURL, options: .atomic)
+        } catch {
+            FileLog.shared.addMessage("What's New: failed to save the read state: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewReadState.swift
+++ b/Modules/Sources/PocketCastsServer/Public/WhatsNew/WhatsNewReadState.swift
@@ -1,10 +1,10 @@
 import Foundation
 import PocketCastsUtils
 
-/// What the user has done with the What's New messages, by message ID.
+/// What the user has done with the What's New messages and the polls they ask.
 ///
-/// Outside of a reset no set ever shrinks — nothing marks a message unread again — so two copies of
-/// the state combine by keeping everything either one has.
+/// Outside of a reset no set ever shrinks — nothing marks a message unread or a poll unanswered
+/// again — so two copies of the state combine by keeping everything either one has.
 public struct WhatsNewReadState: Codable, Hashable, Sendable {
     /// Messages the user opened or cleared with "Read all".
     public var readMessageIDs: Set<String>
@@ -17,10 +17,17 @@ public struct WhatsNewReadState: Codable, Hashable, Sendable {
     /// already pointed them at.
     public var listedMessageIDs: Set<String>
 
-    public init(readMessageIDs: Set<String> = [], seenMessageIDs: Set<String> = [], listedMessageIDs: Set<String> = []) {
+    /// Research polls the user answered, which stay closed from then on.
+    public var respondedPollIDs: Set<String>
+
+    public init(readMessageIDs: Set<String> = [],
+                seenMessageIDs: Set<String> = [],
+                listedMessageIDs: Set<String> = [],
+                respondedPollIDs: Set<String> = []) {
         self.readMessageIDs = readMessageIDs
         self.seenMessageIDs = seenMessageIDs
         self.listedMessageIDs = listedMessageIDs
+        self.respondedPollIDs = respondedPollIDs
     }
 
     public init(from decoder: any Decoder) throws {
@@ -28,6 +35,7 @@ public struct WhatsNewReadState: Codable, Hashable, Sendable {
         readMessageIDs = try container.decodeIfPresent(Set<String>.self, forKey: .readMessageIDs) ?? []
         seenMessageIDs = try container.decodeIfPresent(Set<String>.self, forKey: .seenMessageIDs) ?? []
         listedMessageIDs = try container.decodeIfPresent(Set<String>.self, forKey: .listedMessageIDs) ?? []
+        respondedPollIDs = try container.decodeIfPresent(Set<String>.self, forKey: .respondedPollIDs) ?? []
     }
 
     public func isRead(_ messageID: String) -> Bool {
@@ -47,7 +55,8 @@ public struct WhatsNewReadState: Codable, Hashable, Sendable {
     func merging(_ other: WhatsNewReadState) -> WhatsNewReadState {
         WhatsNewReadState(readMessageIDs: readMessageIDs.union(other.readMessageIDs),
                           seenMessageIDs: seenMessageIDs.union(other.seenMessageIDs),
-                          listedMessageIDs: listedMessageIDs.union(other.listedMessageIDs))
+                          listedMessageIDs: listedMessageIDs.union(other.listedMessageIDs),
+                          respondedPollIDs: respondedPollIDs.union(other.respondedPollIDs))
     }
 }
 

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewManagerTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewManagerTests.swift
@@ -8,6 +8,7 @@ import XCTest
 final class WhatsNewManagerTests: XCTestCase {
     private let messageID = "01K2Y08DAWG9N7XJZX5QTH9Z0K"
     private let otherMessageID = "01K2Y3D5J1H7QZP0B6RXKA4N3T"
+    private let pollID = "01K2Y2S65F22TQZQJVNAEXQKHT"
 
     private let json = """
     {
@@ -146,13 +147,15 @@ final class WhatsNewManagerTests: XCTestCase {
         manager.markAsRead([messageID])
         manager.markAsSeen([otherMessageID])
         manager.markAsListed([messageID])
+        manager.markAsResponded(toPoll: pollID)
 
         let relaunched = self.manager(cache: temporaryCache(), readStateStore: store)
         await relaunched.refreshIfNeeded().value
 
         XCTAssertEqual(relaunched.readState, WhatsNewReadState(readMessageIDs: [messageID],
                                                                seenMessageIDs: [messageID, otherMessageID],
-                                                               listedMessageIDs: [messageID]))
+                                                               listedMessageIDs: [messageID],
+                                                               respondedPollIDs: [pollID]))
     }
 
     /// The saved state predates whatever gets added to it next, and failing to read it would start the
@@ -212,13 +215,14 @@ final class WhatsNewManagerTests: XCTestCase {
         XCTAssertEqual(manager.readState, WhatsNewReadState(seenMessageIDs: [messageID], listedMessageIDs: [messageID]))
     }
 
-    func testResettingForgetsEverythingReadSeenOrListed() async {
+    func testResettingForgetsEverythingReadSeenListedOrAnswered() async {
         let store = temporaryReadStateStore()
         let manager = manager(cache: temporaryCache(), readStateStore: store)
         await manager.refreshIfNeeded().value
         manager.markAsRead([messageID])
         manager.markAsSeen([otherMessageID])
         manager.markAsListed([messageID])
+        manager.markAsResponded(toPoll: pollID)
 
         manager.resetReadState()
 

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewManagerTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewManagerTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import PocketCastsUtils
 @testable import PocketCastsServer
@@ -5,6 +6,9 @@ import XCTest
 
 @MainActor
 final class WhatsNewManagerTests: XCTestCase {
+    private let messageID = "01K2Y08DAWG9N7XJZX5QTH9Z0K"
+    private let otherMessageID = "01K2Y3D5J1H7QZP0B6RXKA4N3T"
+
     private let json = """
     {
       "schemaVersion": 1,
@@ -131,11 +135,76 @@ final class WhatsNewManagerTests: XCTestCase {
         XCTAssertEqual(manager.catalog?.messages.map(\.title), ["Sort your Up Next"])
     }
 
+    // MARK: - Read state
+
+    /// Until read state syncs with the server, the file next to the catalog is all that remembers it.
+    func testReadStateOutlivesTheManager() async {
+        let store = temporaryReadStateStore()
+        let manager = manager(cache: temporaryCache(), readStateStore: store)
+        await manager.refreshIfNeeded().value
+
+        manager.markAsRead([messageID])
+        manager.markAsSeen([otherMessageID])
+
+        let relaunched = self.manager(cache: temporaryCache(), readStateStore: store)
+        await relaunched.refreshIfNeeded().value
+
+        XCTAssertEqual(relaunched.readState, WhatsNewReadState(readMessageIDs: [messageID], seenMessageIDs: [otherMessageID]))
+    }
+
+    /// The unread dots are drawn from the catalog and the read state together, so a message read in
+    /// an earlier session can't be published as unread, even for a moment.
+    func testReadStateIsInPlaceBeforeTheCatalogIsPublished() async {
+        let cache = temporaryCache()
+        cache.save(Data(json.utf8), forLocale: WhatsNewCatalogTask.currentLocale)
+        let store = temporaryReadStateStore()
+        store.save(WhatsNewReadState(readMessageIDs: [messageID]))
+
+        let manager = manager(cache: cache, readStateStore: store)
+        var readStateWhenPublished: WhatsNewReadState?
+        let cancellable = manager.$catalog
+            .compactMap { $0 }
+            .sink { _ in readStateWhenPublished = manager.readState }
+
+        await manager.refreshIfNeeded().value
+        cancellable.cancel()
+
+        XCTAssertEqual(readStateWhenPublished?.readMessageIDs, [messageID])
+    }
+
+    /// A message can be marked read before the first refresh has read the state back, and saving
+    /// that on its own would replace every read before it.
+    func testReadingBeforeTheStateIsLoadedKeepsWhatWasSaved() async {
+        let store = temporaryReadStateStore()
+        store.save(WhatsNewReadState(readMessageIDs: [messageID]))
+
+        let manager = manager(cache: temporaryCache(), readStateStore: store)
+        manager.markAsRead([otherMessageID])
+        await manager.refreshIfNeeded().value
+
+        XCTAssertEqual(manager.readState.readMessageIDs, [messageID, otherMessageID])
+        XCTAssertEqual(store.load().readMessageIDs, [messageID, otherMessageID])
+    }
+
+    func testResettingForgetsEverythingReadOrSeen() async {
+        let store = temporaryReadStateStore()
+        let manager = manager(cache: temporaryCache(), readStateStore: store)
+        await manager.refreshIfNeeded().value
+        manager.markAsRead([messageID])
+        manager.markAsSeen([messageID])
+
+        manager.resetReadState()
+
+        XCTAssertEqual(manager.readState, WhatsNewReadState())
+        XCTAssertEqual(store.load(), WhatsNewReadState())
+    }
+
     // MARK: - Helpers
 
     private var requestCount: Int { StubURLProtocol.requestCount }
 
     private func manager(cache: WhatsNewCatalogCache,
+                         readStateStore: WhatsNewReadStateStore? = nil,
                          refreshInterval: TimeInterval = WhatsNewManager.refreshInterval) -> WhatsNewManager {
         StubURLProtocol.requestHandler = { [json] request in
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
@@ -143,14 +212,22 @@ final class WhatsNewManagerTests: XCTestCase {
         }
 
         let task = WhatsNewCatalogTask(session: StubURLProtocol.session(), cache: cache)
-        return WhatsNewManager(task: task, refreshInterval: refreshInterval)
+        return WhatsNewManager(task: task, readStateStore: readStateStore ?? temporaryReadStateStore(), refreshInterval: refreshInterval)
     }
 
     private func temporaryCache() -> WhatsNewCatalogCache {
+        WhatsNewCatalogCache(directory: temporaryDirectory())
+    }
+
+    private func temporaryReadStateStore() -> WhatsNewReadStateStore {
+        WhatsNewReadStateStore(directory: temporaryDirectory())
+    }
+
+    private func temporaryDirectory() -> URL {
         let directory = URL.temporaryDirectory.appending(path: "whats-new-tests-\(UUID().uuidString)", directoryHint: .isDirectory)
         addTeardownBlock {
             try? FileManager.default.removeItem(at: directory)
         }
-        return WhatsNewCatalogCache(directory: directory)
+        return directory
     }
 }

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewManagerTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewManagerTests.swift
@@ -155,6 +155,18 @@ final class WhatsNewManagerTests: XCTestCase {
                                                                listedMessageIDs: [messageID]))
     }
 
+    /// The saved state predates whatever gets added to it next, and failing to read it would start the
+    /// user over.
+    func testReadStateSavedBeforeASetWasAddedStillLoads() throws {
+        let saved = Data("""
+        { "readMessageIDs": ["\(messageID)"], "seenMessageIDs": ["\(otherMessageID)"] }
+        """.utf8)
+
+        let readState = try JSONDecoder().decode(WhatsNewReadState.self, from: saved)
+
+        XCTAssertEqual(readState, WhatsNewReadState(readMessageIDs: [messageID], seenMessageIDs: [otherMessageID]))
+    }
+
     /// The unread dots are drawn from the catalog and the read state together, so a message read in
     /// an earlier session can't be published as unread, even for a moment.
     func testReadStateIsInPlaceBeforeTheCatalogIsPublished() async {

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewManagerTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewManagerTests.swift
@@ -145,11 +145,14 @@ final class WhatsNewManagerTests: XCTestCase {
 
         manager.markAsRead([messageID])
         manager.markAsSeen([otherMessageID])
+        manager.markAsListed([messageID])
 
         let relaunched = self.manager(cache: temporaryCache(), readStateStore: store)
         await relaunched.refreshIfNeeded().value
 
-        XCTAssertEqual(relaunched.readState, WhatsNewReadState(readMessageIDs: [messageID], seenMessageIDs: [otherMessageID]))
+        XCTAssertEqual(relaunched.readState, WhatsNewReadState(readMessageIDs: [messageID],
+                                                               seenMessageIDs: [messageID, otherMessageID],
+                                                               listedMessageIDs: [messageID]))
     }
 
     /// The unread dots are drawn from the catalog and the read state together, so a message read in
@@ -186,12 +189,24 @@ final class WhatsNewManagerTests: XCTestCase {
         XCTAssertEqual(store.load().readMessageIDs, [messageID, otherMessageID])
     }
 
-    func testResettingForgetsEverythingReadOrSeen() async {
+    /// The Profile tab points the user at the feed, so once the feed has listed a message the tab has
+    /// nothing left to point at.
+    func testListingMessagesMarksThemSeen() async {
+        let manager = manager(cache: temporaryCache())
+        await manager.refreshIfNeeded().value
+
+        manager.markAsListed([messageID])
+
+        XCTAssertEqual(manager.readState, WhatsNewReadState(seenMessageIDs: [messageID], listedMessageIDs: [messageID]))
+    }
+
+    func testResettingForgetsEverythingReadSeenOrListed() async {
         let store = temporaryReadStateStore()
         let manager = manager(cache: temporaryCache(), readStateStore: store)
         await manager.refreshIfNeeded().value
         manager.markAsRead([messageID])
-        manager.markAsSeen([messageID])
+        manager.markAsSeen([otherMessageID])
+        manager.markAsListed([messageID])
 
         manager.resetReadState()
 

--- a/Modules/Tests/PocketCastsServerTests/WhatsNewManagerTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/WhatsNewManagerTests.swift
@@ -137,7 +137,7 @@ final class WhatsNewManagerTests: XCTestCase {
 
     // MARK: - Read state
 
-    /// Until read state syncs with the server, the file next to the catalog is all that remembers it.
+    /// Until read state syncs with the server, the file on disk is all that remembers it.
     func testReadStateOutlivesTheManager() async {
         let store = temporaryReadStateStore()
         let manager = manager(cache: temporaryCache(), readStateStore: store)

--- a/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
@@ -185,7 +185,7 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.items.map(\.title), ["Folders for everyone", "Sort your Up Next"])
     }
 
-    /// Reads live in memory until read-state sync lands, so a refresh must not undo them.
+    /// A refresh publishes the catalog again, which mustn't undo what was read.
     func testReloadingTheCatalogKeepsWhatWasRead() async throws {
         let viewModel = WhatsNewFeedViewModel(manager: manager(publishing: Self.catalogJSON), targeting: targeting)
         await viewModel.load()
@@ -205,6 +205,89 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.items.count, messages.count)
     }
 
+    // MARK: - Read state
+
+    /// Reads go through the manager, so the feed opens on them next time and the dots on Profile agree.
+    func testSelectingARowMarksItsMessageReadInTheManager() async throws {
+        let manager = manager(publishing: Self.catalogJSON)
+        let viewModel = WhatsNewFeedViewModel(manager: manager, targeting: targeting)
+        await viewModel.load()
+
+        viewModel.select(try XCTUnwrap(viewModel.items.first))
+
+        XCTAssertEqual(manager.readState.readMessageIDs, [Self.tipID])
+        XCTAssertFalse(WhatsNewFeedViewModel(manager: manager, targeting: targeting).hasUnreadItems)
+    }
+
+    /// "Read all" can only vouch for the messages the user was shown.
+    func testReadingEverythingLeavesOutMessagesTheFeedDoesNotShow() async {
+        let manager = manager(publishing: Self.catalogWithPatronMessageJSON)
+        let viewModel = WhatsNewFeedViewModel(manager: manager, targeting: targeting)
+        await viewModel.load()
+
+        viewModel.markAllAsRead()
+
+        XCTAssertEqual(manager.readState.readMessageIDs, [Self.tipID])
+    }
+
+    /// The read state can be reset from the developer menu while a feed is open.
+    func testResettingTheReadStateBringsBackTheFeedsIndicators() async {
+        let manager = manager(publishing: Self.catalogJSON)
+        let viewModel = WhatsNewFeedViewModel(manager: manager, targeting: targeting)
+        await viewModel.load()
+        viewModel.markAllAsRead()
+
+        manager.resetReadState()
+
+        XCTAssertTrue(viewModel.hasUnreadItems)
+    }
+
+    // MARK: - Profile indicators
+
+    func testTappingTheProfileTabTakesItsDotOffWithoutReadingAnything() async {
+        let manager = manager(publishing: Self.catalogJSON)
+        await manager.refreshIfNeeded().value
+        XCTAssertTrue(manager.hasUnseenMessages(targeting: targeting))
+
+        manager.markFeedAsSeen(targeting: targeting)
+
+        XCTAssertFalse(manager.hasUnseenMessages(targeting: targeting))
+        XCTAssertTrue(manager.hasUnreadMessages(targeting: targeting))
+    }
+
+    func testANewMessagePutsTheDotBackOnTheProfileTab() async {
+        let manager = manager(publishing: Self.catalogJSON, refreshInterval: 0)
+        await manager.refreshIfNeeded().value
+        manager.markFeedAsSeen(targeting: targeting)
+
+        publish(Self.catalogWithNewMessageJSON)
+        await manager.refreshIfNeeded().value
+
+        XCTAssertTrue(manager.hasUnseenMessages(targeting: targeting))
+    }
+
+    func testReadingEverythingTakesBothDotsOffProfile() async {
+        let manager = manager(publishing: Self.catalogJSON)
+        let viewModel = WhatsNewFeedViewModel(manager: manager, targeting: targeting)
+        await viewModel.load()
+
+        viewModel.markAllAsRead()
+
+        XCTAssertFalse(manager.hasUnreadMessages(targeting: targeting))
+        XCTAssertFalse(manager.hasUnseenMessages(targeting: targeting))
+    }
+
+    /// A dot on Profile has to lead to a row in the feed.
+    func testProfileDotsIgnoreMessagesTheFeedDoesNotShow() async {
+        let manager = manager(publishing: Self.catalogWithPatronMessageJSON)
+        await manager.refreshIfNeeded().value
+
+        manager.markAsRead([Self.tipID])
+
+        XCTAssertFalse(manager.hasUnreadMessages(targeting: targeting))
+        XCTAssertFalse(manager.hasUnseenMessages(targeting: targeting))
+    }
+
     // MARK: - Helpers
 
     override func tearDown() {
@@ -220,7 +303,8 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
     }
 
     /// A manager whose catalog answers with `json`, or fails every request until something is published.
-    private func manager(publishing json: String? = nil) -> WhatsNewManager {
+    private func manager(publishing json: String? = nil,
+                         refreshInterval: TimeInterval = WhatsNewManager.refreshInterval) -> WhatsNewManager {
         if let json {
             publish(json)
         }
@@ -235,7 +319,9 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
 
         let task = WhatsNewCatalogTask(session: URLSession(configuration: configuration),
                                        cache: WhatsNewCatalogCache(directory: directory))
-        return WhatsNewManager(task: task)
+        return WhatsNewManager(task: task,
+                               readStateStore: WhatsNewReadStateStore(directory: directory),
+                               refreshInterval: refreshInterval)
     }
 
     private func publish(_ json: String) {
@@ -244,6 +330,8 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
             return (response, Data(json.utf8))
         }
     }
+
+    private static let tipID = "550e8400-e29b-41d4-a716-446655440001"
 
     private static let page = """
     {
@@ -269,9 +357,49 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
     private static let catalogJSON = """
     {
       "schemaVersion": 1,
-      "messages": [\(tip(id: "550e8400-e29b-41d4-a716-446655440001",
+      "messages": [\(tip(id: tipID,
                          title: "Sort your Up Next",
                          publishedAt: "2026-08-17T08:00:00Z"))]
+    }
+    """
+
+    /// The tip, and a message a free account isn't shown.
+    private static let catalogWithPatronMessageJSON = """
+    {
+      "schemaVersion": 1,
+      "messages": [
+        \(tip(id: tipID,
+              title: "Sort your Up Next",
+              publishedAt: "2026-08-17T08:00:00Z")),
+        {
+          "id": "550e8400-e29b-41d4-a716-446655440002",
+          "type": "announcement",
+          "publishedAt": "2026-08-18T08:00:00Z",
+          "targeting": { "audiences": ["patron"] },
+          "title": "Thanks for being a Patron",
+          "pages": [\(page)]
+        }
+      ]
+    }
+    """
+
+    /// The tip, and a message published after it.
+    private static let catalogWithNewMessageJSON = """
+    {
+      "schemaVersion": 1,
+      "messages": [
+        \(tip(id: tipID,
+              title: "Sort your Up Next",
+              publishedAt: "2026-08-17T08:00:00Z")),
+        {
+          "id": "550e8400-e29b-41d4-a716-446655440003",
+          "type": "new_feature",
+          "publishedAt": "2026-08-19T08:00:00Z",
+          "targeting": { "audiences": [] },
+          "title": "Introducing Playlists",
+          "pages": [\(page)]
+        }
+      ]
     }
     """
 }

--- a/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
@@ -242,6 +242,18 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasUnreadItems)
     }
 
+    /// Profile builds a new feed each time the row is tapped, so an answer has to outlast the feed it
+    /// was given in.
+    func testAPollAnsweredInAnEarlierFeedStaysAnswered() throws {
+        let manager = manager()
+        let message = try XCTUnwrap(messages.first { $0.type == .research })
+        let poll = try XCTUnwrap(message.content.research?.poll)
+
+        WhatsNewFeedViewModel(manager: manager, targeting: targeting).markAsResponded(to: poll)
+
+        XCTAssertTrue(WhatsNewFeedViewModel(manager: manager, targeting: targeting).hasResponded(to: message))
+    }
+
     // MARK: - Profile indicators
 
     func testTappingTheProfileTabTakesOnlyItsOwnDotOff() async {

--- a/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewFeedViewModelTests.swift
@@ -59,7 +59,7 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
     }
 
     /// The catalog is published per platform and locale, so the rest of the targeting is the
-    /// client's to apply — including to the unread count the Profile row is drawn from.
+    /// client's to apply — including to whether the feed has anything unread.
     func testMessagesThisUserIsNotTargetedByNeverReachTheFeed() throws {
         let messages = try decodedMessages(json: """
         {
@@ -244,7 +244,7 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
 
     // MARK: - Profile indicators
 
-    func testTappingTheProfileTabTakesItsDotOffWithoutReadingAnything() async {
+    func testTappingTheProfileTabTakesOnlyItsOwnDotOff() async {
         let manager = manager(publishing: Self.catalogJSON)
         await manager.refreshIfNeeded().value
         XCTAssertTrue(manager.hasUnseenMessages(targeting: targeting))
@@ -252,7 +252,20 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
         manager.markFeedAsSeen(targeting: targeting)
 
         XCTAssertFalse(manager.hasUnseenMessages(targeting: targeting))
-        XCTAssertTrue(manager.hasUnreadMessages(targeting: targeting))
+        XCTAssertTrue(manager.hasUnlistedMessages(targeting: targeting))
+    }
+
+    /// The dot on the What's New row points at the feed, not at what's unread in it.
+    func testOpeningTheFeedTakesBothDotsOffWithoutReadingAnything() async {
+        let manager = manager(publishing: Self.catalogJSON)
+        await manager.refreshIfNeeded().value
+        XCTAssertTrue(manager.hasUnlistedMessages(targeting: targeting))
+
+        let viewModel = WhatsNewFeedViewModel(manager: manager, targeting: targeting)
+
+        XCTAssertFalse(manager.hasUnlistedMessages(targeting: targeting))
+        XCTAssertFalse(manager.hasUnseenMessages(targeting: targeting))
+        XCTAssertTrue(viewModel.hasUnreadItems)
     }
 
     func testANewMessagePutsTheDotBackOnTheProfileTab() async {
@@ -266,15 +279,16 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
         XCTAssertTrue(manager.hasUnseenMessages(targeting: targeting))
     }
 
-    func testReadingEverythingTakesBothDotsOffProfile() async {
-        let manager = manager(publishing: Self.catalogJSON)
-        let viewModel = WhatsNewFeedViewModel(manager: manager, targeting: targeting)
-        await viewModel.load()
+    /// The feed can open before the catalog is in, so what it goes on to list counts as well.
+    func testANewMessagePutsTheDotBackOnTheWhatsNewRow() async {
+        let manager = manager(publishing: Self.catalogJSON, refreshInterval: 0)
+        await WhatsNewFeedViewModel(manager: manager, targeting: targeting).load()
+        XCTAssertFalse(manager.hasUnlistedMessages(targeting: targeting))
 
-        viewModel.markAllAsRead()
+        publish(Self.catalogWithNewMessageJSON)
+        await manager.refreshIfNeeded().value
 
-        XCTAssertFalse(manager.hasUnreadMessages(targeting: targeting))
-        XCTAssertFalse(manager.hasUnseenMessages(targeting: targeting))
+        XCTAssertTrue(manager.hasUnlistedMessages(targeting: targeting))
     }
 
     /// A dot on Profile has to lead to a row in the feed.
@@ -282,9 +296,9 @@ final class WhatsNewFeedViewModelTests: XCTestCase {
         let manager = manager(publishing: Self.catalogWithPatronMessageJSON)
         await manager.refreshIfNeeded().value
 
-        manager.markAsRead([Self.tipID])
+        manager.markAsListed([Self.tipID])
 
-        XCTAssertFalse(manager.hasUnreadMessages(targeting: targeting))
+        XCTAssertFalse(manager.hasUnlistedMessages(targeting: targeting))
         XCTAssertFalse(manager.hasUnseenMessages(targeting: targeting))
     }
 

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -432,6 +432,13 @@ struct DeveloperMenu: View {
                 Text("Up Next")
             }
             Section {
+                Button("Reset Read State") {
+                    WhatsNewManager.shared.resetReadState()
+                }
+            } header: {
+                Text("What's New Feed")
+            }
+            Section {
                 Text(Bundle.main.identifier)
             } header: {
                 Text("Bundle ID")

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -17,7 +17,15 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     lazy var endOfYear = EndOfYear()
 
-    private lazy var profileTabBarItem = UITabBarItem(title: L10n.profile, image: UIImage(named: "profile_tab"), tag: pcTabs.firstIndex(of: .profile) ?? -1)
+    /// Styles its badge as a plain red dot on the item itself, since Liquid Glass ignores the tab bar
+    /// appearance that does it for the older tab bar.
+    private lazy var profileTabBarItem: UITabBarItem = {
+        let item = UITabBarItem(title: L10n.profile, image: UIImage(named: "profile_tab"), tag: pcTabs.firstIndex(of: .profile) ?? -1)
+        item.badgeColor = .clear
+        item.setBadgeTextAttributes([.foregroundColor: UIColor.systemRed], for: .normal)
+        item.setBadgeTextAttributes([.foregroundColor: UIColor.systemRed], for: .selected)
+        return item
+    }()
 
     private lazy var upNextTabBarItem = UITabBarItem(title: L10n.upNext, image: UIImage(named: "upnext_tab"), tag: pcTabs.firstIndex(of: .upNext) ?? -1)
 
@@ -156,6 +164,8 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         // `upNextEpisodeAdded` refreshes the badge via the genie animation's tail, not here.
         NotificationCenter.default.addObserver(self, selector: #selector(animateEpisodeAddedToUpNext(_:)), name: Constants.Notifications.upNextEpisodeAdded, object: nil)
         refreshUpNextTabBadge()
+
+        observeWhatsNewFeed()
 
         observersForEndOfYearStats()
         addBookmarkCreatedToastHandler()
@@ -322,6 +332,10 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
             let tab = pcTabs[tabIndex]
             trackTabOpened(tab)
             AnalyticsHelper.tabSelected(tab: tab)
+        }
+
+        if item === profileTabBarItem, FeatureFlag.whatsNewFeed.enabled {
+            WhatsNewManager.shared.markFeedAsSeen()
         }
 
         UserDefaults.standard.set(tabIndex, forKey: Constants.UserDefaults.lastTabOpened)
@@ -788,8 +802,12 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     // MARK: - End of Year
 
+    /// Whether End of Year has a badge waiting on the Profile tab, which it shares with What's New.
+    private var showsEndOfYearBadge = false
+
     @objc private func profileSeen() {
-        profileTabBarItem.badgeValue = nil
+        showsEndOfYearBadge = false
+        updateProfileTabBadge()
         if let year = endOfYear.storyModelType?.year {
             Settings.setShowBadgeForEndOfYear(false, year: year)
         }
@@ -867,7 +885,8 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     private func displayEndOfYearBadgeIfNeeded() {
         if EndOfYear.isEligible, let year = endOfYear.storyModelType?.year, Settings.showBadgeForEndOfYear(year) {
-            profileTabBarItem.badgeValue = "●"
+            showsEndOfYearBadge = true
+            updateProfileTabBadge()
         }
     }
 
@@ -1325,5 +1344,33 @@ extension MainTabBarController {
     func resetUpNextTabImage() {
         upNextTabBarItem.image = UIImage(named: "upnext_tab")
         upNextTabBarItem.selectedImage = nil
+    }
+}
+
+// MARK: - What's New
+
+private extension MainTabBarController {
+    /// Keeps the dot on the Profile tab in step with the feed: it shows while the feed has an unread
+    /// message the tab hasn't pointed the user at, and tapping the tab takes it off.
+    func observeWhatsNewFeed() {
+        guard FeatureFlag.whatsNewFeed.enabled else { return }
+
+        let manager = WhatsNewManager.shared
+        Publishers.Merge3(
+            manager.$catalog.map { _ in },
+            manager.$readState.map { _ in },
+            NotificationCenter.default.publisher(for: ServerNotifications.subscriptionStatusChanged).map { _ in }
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] _ in
+            self?.updateProfileTabBadge()
+        }
+        .store(in: &cancellables)
+    }
+
+    /// Shows the dot while End of Year or What's New has something waiting on Profile.
+    func updateProfileTabBadge() {
+        let showsWhatsNewBadge = FeatureFlag.whatsNewFeed.enabled && WhatsNewManager.shared.hasUnseenMessages()
+        profileTabBarItem.badgeValue = showsEndOfYearBadge || showsWhatsNewBadge ? "●" : nil
     }
 }

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -1,3 +1,4 @@
+import Combine
 import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
@@ -125,6 +126,8 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         return view
     }()
 
+    private var cancellables = Set<AnyCancellable>()
+
     // MARK: - View Events
 
     override func viewDidLoad() {
@@ -148,6 +151,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         updateFooterFrame()
         setupRefreshControl()
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: profileTable)
+        observeWhatsNewFeed()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -356,6 +360,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         cell.settingsImage.tintColor = ThemeColor.primaryIcon01()
         cell.settingsLabel.setLetterSpacing(-0.01)
         cell.separatorInset = .zero
+        cell.showsUnreadIndicator = false
 
         switch row {
         case .informationalBanner:
@@ -367,6 +372,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         case .whatsNew:
             cell.settingsImage.image = UIImage(named: "mail")
             cell.settingsLabel.text = L10n.whatsNew
+            cell.showsUnreadIndicator = WhatsNewManager.shared.hasUnreadMessages()
         case .allStats:
             cell.settingsImage.image = UIImage(named: "profile-stats")
             cell.settingsLabel.text = L10n.settingsStats
@@ -662,6 +668,33 @@ extension ProfileViewController: PlusLockedInfoDelegate {
 
     var displaySource: PlusUpgradeViewSource {
         .profile
+    }
+}
+
+// MARK: - What's New
+
+private extension ProfileViewController {
+    /// Keeps the dot on the What's New row in step with the feed while Profile is on screen.
+    func observeWhatsNewFeed() {
+        guard FeatureFlag.whatsNewFeed.enabled else { return }
+
+        let manager = WhatsNewManager.shared
+        manager.$catalog.combineLatest(manager.$readState)
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateWhatsNewRow()
+            }
+            .store(in: &cancellables)
+    }
+
+    func updateWhatsNewRow() {
+        guard let section = tableData.firstIndex(where: { $0.contains(.whatsNew) }),
+              let row = tableData[section].firstIndex(of: .whatsNew),
+              let cell = profileTable.cellForRow(at: IndexPath(row: row, section: section)) as? TopLevelSettingsCell else {
+            return
+        }
+        cell.showsUnreadIndicator = WhatsNewManager.shared.hasUnreadMessages()
     }
 }
 

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -372,7 +372,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         case .whatsNew:
             cell.settingsImage.image = UIImage(named: "mail")
             cell.settingsLabel.text = L10n.whatsNew
-            cell.showsUnreadIndicator = WhatsNewManager.shared.hasUnreadMessages()
+            cell.showsUnreadIndicator = WhatsNewManager.shared.hasUnlistedMessages()
         case .allStats:
             cell.settingsImage.image = UIImage(named: "profile-stats")
             cell.settingsLabel.text = L10n.settingsStats
@@ -694,7 +694,7 @@ private extension ProfileViewController {
               let cell = profileTable.cellForRow(at: IndexPath(row: row, section: section)) as? TopLevelSettingsCell else {
             return
         }
-        cell.showsUnreadIndicator = WhatsNewManager.shared.hasUnreadMessages()
+        cell.showsUnreadIndicator = WhatsNewManager.shared.hasUnlistedMessages()
     }
 }
 

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -192,6 +192,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         }
 
         whatsNewDismissed()
+        markWhatsNewFeedAsSeenIfOnScreen()
 
         if FeatureFlag.cancelSubscriptionSurvey.enabled,
            SyncManager.isUserLoggedIn(),
@@ -674,7 +675,8 @@ extension ProfileViewController: PlusLockedInfoDelegate {
 // MARK: - What's New
 
 private extension ProfileViewController {
-    /// Keeps the dot on the What's New row in step with the feed while Profile is on screen.
+    /// Keeps the dot on the What's New row in step with the feed, and the dot on the tab off, while
+    /// Profile is on screen.
     func observeWhatsNewFeed() {
         guard FeatureFlag.whatsNewFeed.enabled else { return }
 
@@ -684,8 +686,14 @@ private extension ProfileViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.updateWhatsNewRow()
+                self?.markWhatsNewFeedAsSeenIfOnScreen()
             }
             .store(in: &cancellables)
+    }
+
+    func markWhatsNewFeedAsSeenIfOnScreen() {
+        guard FeatureFlag.whatsNewFeed.enabled, view.window != nil else { return }
+        WhatsNewManager.shared.markFeedAsSeen()
     }
 
     func updateWhatsNewRow() {

--- a/podcasts/TopLevelSettingsCell.swift
+++ b/podcasts/TopLevelSettingsCell.swift
@@ -11,9 +11,11 @@ class TopLevelSettingsCell: ThemeableCell {
     @IBOutlet var plusIndicator: UIImageView!
 
     private var disclosureImageView: TintableImageView?
+    private var unreadIndicator: UIView?
 
     private let baseSettingsImageSize: CGFloat = 24
     private let baseDisclosureSize: CGFloat = 32
+    private let baseUnreadIndicatorSize: CGFloat = 8
 
     var showsDisclosureIndicator = true {
         didSet {
@@ -23,6 +25,16 @@ class TopLevelSettingsCell: ThemeableCell {
                 disclosureImageView = nil
                 accessoryView = nil
             }
+        }
+    }
+
+    /// Whether the row shows a dot for something new behind it, such as an unread What's New message.
+    var showsUnreadIndicator = false {
+        didSet {
+            if showsUnreadIndicator, unreadIndicator == nil {
+                setupUnreadIndicator()
+            }
+            unreadIndicator?.isHidden = !showsUnreadIndicator
         }
     }
 
@@ -50,6 +62,25 @@ class TopLevelSettingsCell: ThemeableCell {
         accessoryView = imageView
     }
 
+    private func setupUnreadIndicator() {
+        let indicator = UIView()
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.isUserInteractionEnabled = false
+        indicator.backgroundColor = ThemeColor.support05()
+        contentView.addSubview(indicator)
+
+        NSLayoutConstraint.activate([
+            indicator.widthAnchor.constraint(equalToConstant: baseUnreadIndicatorSize),
+            indicator.heightAnchor.constraint(equalToConstant: baseUnreadIndicatorSize),
+            indicator.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            indicator.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            indicator.leadingAnchor.constraint(greaterThanOrEqualTo: plusIndicator.trailingAnchor, constant: 8)
+        ])
+
+        unreadIndicator = indicator
+        updateSize()
+    }
+
     private func updateSize() {
         let metric = UIFontMetrics(forTextStyle: .largeTitle)
 
@@ -60,9 +91,14 @@ class TopLevelSettingsCell: ThemeableCell {
 
         let disclosureSize = max(baseDisclosureSize, metric.scaledValue(for: baseDisclosureSize))
         disclosureImageView?.frame.size = CGSize(width: disclosureSize, height: disclosureSize)
+
+        let unreadIndicatorSize = max(baseUnreadIndicatorSize, UIFontMetrics(forTextStyle: .caption2).scaledValue(for: baseUnreadIndicatorSize))
+        unreadIndicator?.updateSizeConstraints(to: unreadIndicatorSize)
+        unreadIndicator?.layer.cornerRadius = unreadIndicatorSize / 2
     }
 
     override func handleThemeDidChange() {
         settingsImage.tintColor = ThemeColor.primaryIcon01()
+        unreadIndicator?.backgroundColor = ThemeColor.support05()
     }
 }

--- a/podcasts/TopLevelSettingsCell.swift
+++ b/podcasts/TopLevelSettingsCell.swift
@@ -28,7 +28,8 @@ class TopLevelSettingsCell: ThemeableCell {
         }
     }
 
-    /// Whether the row shows a dot for something new behind it, such as an unread What's New message.
+    /// Whether the row shows a dot for something new behind it, such as a What's New message that
+    /// arrived since the feed was last opened.
     var showsUnreadIndicator = false {
         didSet {
             if showsUnreadIndicator, unreadIndicator == nil {

--- a/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import PocketCastsServer
 
@@ -49,13 +50,24 @@ final class WhatsNewFeedViewModel: ObservableObject {
     private var respondedPollIDs: Set<String> = []
     private let manager: WhatsNewManager?
     private let targeting: WhatsNewMessageFilter
+    private var cancellables = Set<AnyCancellable>()
 
+    /// A feed of the manager's catalog, which saves what's read through the manager and follows
+    /// the manager's read state wherever else it changes.
     init(manager: WhatsNewManager = .shared, targeting: WhatsNewMessageFilter = .current) {
         self.manager = manager
         self.targeting = targeting
-        readMessageIDs = []
+        readMessageIDs = manager.readState.readMessageIDs
         state = manager.catalog == nil ? .loading : .loaded
         show(manager.catalog?.messages ?? [])
+
+        manager.$readState
+            .dropFirst()
+            .sink { [weak self] readState in
+                self?.readMessageIDs = readState.readMessageIDs
+                self?.updateItems()
+            }
+            .store(in: &cancellables)
     }
 
     init(messages: [WhatsNewMessage], readMessageIDs: Set<String> = [], targeting: WhatsNewMessageFilter = .current) {
@@ -95,17 +107,15 @@ final class WhatsNewFeedViewModel: ObservableObject {
     }
 
     func select(_ item: WhatsNewFeedItem) {
-        markAsRead(item.id)
+        markAsRead([item.id])
 
         guard let message = messages.first(where: { $0.id == item.id }) else { return }
         onSelect?(message)
     }
 
+    /// Marks every message the feed shows read, and none of the ones it leaves out.
     func markAllAsRead() {
-        readMessageIDs.formUnion(items.map(\.id))
-        for index in items.indices {
-            items[index].isUnread = false
-        }
+        markAsRead(items.map(\.id))
     }
 
     /// Whether the poll the message asks, if it asks one, has already been answered.
@@ -121,11 +131,17 @@ final class WhatsNewFeedViewModel: ObservableObject {
         respondedPollIDs.insert(poll.pollId)
     }
 
-    private func markAsRead(_ id: WhatsNewFeedItem.ID) {
-        readMessageIDs.insert(id)
+    /// The messages the feed lists out of `messages`, most recently published first.
+    static func feedMessages(from messages: [WhatsNewMessage], targeting: WhatsNewMessageFilter) -> [WhatsNewMessage] {
+        messages
+            .filter { targeting.includes($0) }
+            .sorted { $0.publishedAt > $1.publishedAt }
+    }
 
-        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
-        items[index].isUnread = false
+    private func markAsRead(_ ids: [WhatsNewFeedItem.ID]) {
+        readMessageIDs.formUnion(ids)
+        manager?.markAsRead(ids)
+        updateItems()
     }
 
     private func showCatalog(of manager: WhatsNewManager) {
@@ -139,9 +155,13 @@ final class WhatsNewFeedViewModel: ObservableObject {
     }
 
     private func show(_ messages: [WhatsNewMessage]) {
-        self.messages = messages
-            .filter { targeting.includes($0) }
-            .sorted { $0.publishedAt > $1.publishedAt }
-        items = self.messages.map { WhatsNewFeedItem(message: $0, isUnread: !readMessageIDs.contains($0.id)) }
+        self.messages = Self.feedMessages(from: messages, targeting: targeting)
+        updateItems()
+    }
+
+    private func updateItems() {
+        let items = messages.map { WhatsNewFeedItem(message: $0, isUnread: !readMessageIDs.contains($0.id)) }
+        guard items != self.items else { return }
+        self.items = items
     }
 }

--- a/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
@@ -52,8 +52,8 @@ final class WhatsNewFeedViewModel: ObservableObject {
     private let targeting: WhatsNewMessageFilter
     private var cancellables = Set<AnyCancellable>()
 
-    /// A feed of the manager's catalog, which saves what's read through the manager and follows
-    /// the manager's read state wherever else it changes.
+    /// A feed of the manager's catalog, which records what it lists and what's read through the
+    /// manager, and follows the manager's read state wherever else it changes.
     init(manager: WhatsNewManager = .shared, targeting: WhatsNewMessageFilter = .current) {
         self.manager = manager
         self.targeting = targeting
@@ -156,6 +156,7 @@ final class WhatsNewFeedViewModel: ObservableObject {
 
     private func show(_ messages: [WhatsNewMessage]) {
         self.messages = Self.feedMessages(from: messages, targeting: targeting)
+        manager?.markAsListed(self.messages.map(\.id))
         updateItems()
     }
 

--- a/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedViewModel.swift
@@ -52,12 +52,13 @@ final class WhatsNewFeedViewModel: ObservableObject {
     private let targeting: WhatsNewMessageFilter
     private var cancellables = Set<AnyCancellable>()
 
-    /// A feed of the manager's catalog, which records what it lists and what's read through the
-    /// manager, and follows the manager's read state wherever else it changes.
+    /// A feed of the manager's catalog, which records what it lists, what's read and which polls are
+    /// answered through the manager, and follows the manager's read state wherever else it changes.
     init(manager: WhatsNewManager = .shared, targeting: WhatsNewMessageFilter = .current) {
         self.manager = manager
         self.targeting = targeting
         readMessageIDs = manager.readState.readMessageIDs
+        respondedPollIDs = manager.readState.respondedPollIDs
         state = manager.catalog == nil ? .loading : .loaded
         show(manager.catalog?.messages ?? [])
 
@@ -65,6 +66,7 @@ final class WhatsNewFeedViewModel: ObservableObject {
             .dropFirst()
             .sink { [weak self] readState in
                 self?.readMessageIDs = readState.readMessageIDs
+                self?.respondedPollIDs = readState.respondedPollIDs
                 self?.updateItems()
             }
             .store(in: &cancellables)
@@ -120,8 +122,8 @@ final class WhatsNewFeedViewModel: ObservableObject {
 
     /// Whether the poll the message asks, if it asks one, has already been answered.
     ///
-    /// Answers stay put for as long as the feed is around, so a poll answered and backed out of
-    /// doesn't offer itself again when the message is opened a second time.
+    /// Answers are kept with the read state, so a poll doesn't offer itself again however many times
+    /// the message is opened.
     func hasResponded(to message: WhatsNewMessage) -> Bool {
         guard let poll = message.content.research?.poll else { return false }
         return respondedPollIDs.contains(poll.pollId)
@@ -129,6 +131,7 @@ final class WhatsNewFeedViewModel: ObservableObject {
 
     func markAsResponded(to poll: WhatsNewPoll) {
         respondedPollIDs.insert(poll.pollId)
+        manager?.markAsResponded(toPoll: poll.pollId)
     }
 
     /// The messages the feed lists out of `messages`, most recently published first.

--- a/podcasts/Whats New/Feed/WhatsNewManager+Feed.swift
+++ b/podcasts/Whats New/Feed/WhatsNewManager+Feed.swift
@@ -10,9 +10,10 @@ extension WhatsNewManager {
         WhatsNewFeedViewModel.feedMessages(from: catalog?.messages ?? [], targeting: targeting)
     }
 
-    /// Whether the feed has a message the user hasn't read, which puts a dot on the What's New row.
-    func hasUnreadMessages(targeting: WhatsNewMessageFilter = .current) -> Bool {
-        feedMessages(targeting: targeting).contains { !readState.isRead($0.id) }
+    /// Whether the feed has a message that arrived since the user last opened it, which puts a dot on
+    /// the What's New row.
+    func hasUnlistedMessages(targeting: WhatsNewMessageFilter = .current) -> Bool {
+        feedMessages(targeting: targeting).contains { !readState.isListed($0.id) }
     }
 
     /// Whether the feed has an unread message the Profile tab hasn't pointed the user at yet, which

--- a/podcasts/Whats New/Feed/WhatsNewManager+Feed.swift
+++ b/podcasts/Whats New/Feed/WhatsNewManager+Feed.swift
@@ -1,0 +1,28 @@
+import PocketCastsServer
+
+/// The What's New feed as the rest of the app sees it.
+///
+/// The feed's rows, the dots on Profile pointing at them, and "Read all" all work from the same
+/// list of messages, so a dot never counts a message the feed leaves out.
+extension WhatsNewManager {
+    /// The catalog's messages the feed lists for this user, most recently published first.
+    func feedMessages(targeting: WhatsNewMessageFilter = .current) -> [WhatsNewMessage] {
+        WhatsNewFeedViewModel.feedMessages(from: catalog?.messages ?? [], targeting: targeting)
+    }
+
+    /// Whether the feed has a message the user hasn't read, which puts a dot on the What's New row.
+    func hasUnreadMessages(targeting: WhatsNewMessageFilter = .current) -> Bool {
+        feedMessages(targeting: targeting).contains { !readState.isRead($0.id) }
+    }
+
+    /// Whether the feed has an unread message the Profile tab hasn't pointed the user at yet, which
+    /// puts a dot on the tab.
+    func hasUnseenMessages(targeting: WhatsNewMessageFilter = .current) -> Bool {
+        feedMessages(targeting: targeting).contains { readState.isUnseen($0.id) }
+    }
+
+    /// Takes the dot off the Profile tab until a message arrives that it hasn't pointed at.
+    func markFeedAsSeen(targeting: WhatsNewMessageFilter = .current) {
+        markAsSeen(feedMessages(targeting: targeting).map(\.id))
+    }
+}


### PR DESCRIPTION
| 📘 Part of: What's New Messages |
|:---:|

Part of PCIOS-926

Saves What's New read state (in a file next to the cached catalog, until server sync lands) and uses it for two dots: one on the Profile tab, cleared by tapping the tab, and one on the What's New row, cleared as soon as the feed is opened. Both come back when a new message arrives. Adds **Reset Read State** to the developer menu.

## To test

1. Enable the `whatsNewFeed` flag and restart on a tab other than Profile.
2. The Profile tab has a dot. Tap it: the tab dot goes away, the What's New row still has one.
3. Open What's New and go back. The row dot is gone, though the messages are still unread.
4. Open a message, then kill and relaunch. It's still read, and neither dot is back.
5. Developer menu → **Reset Read State**. Both dots come back.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
