### PR TITLE
Track What's New feed analytics

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -899,6 +899,11 @@ enum AnalyticsEvent: String {
 
     // MARK: - What's New Feed
 
+    case whatsNewFeedShown
+    case whatsNewMessageShown
+    case whatsNewActionTapped
+    case whatsNewReadAllTapped
+
     /// The first answer an account gives a research poll, which is where its results are counted.
     case whatsNewPollResponseSubmitted
 

--- a/podcasts/Whats New/Feed/WhatsNewFeedViewController.swift
+++ b/podcasts/Whats New/Feed/WhatsNewFeedViewController.swift
@@ -22,6 +22,8 @@ class WhatsNewFeedViewController: PCHostingController<WhatsNewFeedView> {
         title = L10n.whatsNew
         navigationItem.largeTitleDisplayMode = .never
 
+        Analytics.track(.whatsNewFeedShown)
+
         viewModel.onSelect = { [weak self] message in
             self?.show(message)
         }
@@ -51,6 +53,7 @@ class WhatsNewFeedViewController: PCHostingController<WhatsNewFeedView> {
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             title: L10n.whatsNewFeedReadAll,
             primaryAction: UIAction { [weak self] _ in
+                Analytics.track(.whatsNewReadAllTapped)
                 self?.viewModel.markAllAsRead()
             }
         )

--- a/podcasts/Whats New/Message/WhatsNewMessageView.swift
+++ b/podcasts/Whats New/Message/WhatsNewMessageView.swift
@@ -15,7 +15,7 @@ struct WhatsNewMessageView: View {
     private var content: some View {
         switch viewModel.content {
         case .pages(let pages):
-            WhatsNewPagesView(pages: pages)
+            WhatsNewPagesView(pages: pages, perform: viewModel.perform)
         case .research(let research):
             WhatsNewPollView(research: research, viewModel: viewModel)
         }
@@ -27,12 +27,13 @@ private struct WhatsNewPagesView: View {
     @State private var currentPage = 0
 
     let pages: [WhatsNewMessageViewModel.Page]
+    let perform: (WhatsNewMessageViewModel.Action) -> Void
 
     var body: some View {
         VStack(spacing: 0) {
             TabView(selection: $currentPage) {
                 ForEach(pages) { page in
-                    WhatsNewMessagePageView(page: page)
+                    WhatsNewMessagePageView(page: page, perform: perform)
                         .tag(page.id)
                 }
             }
@@ -57,6 +58,7 @@ private struct WhatsNewMessagePageView: View {
     private let horizontalPadding: CGFloat = 20
 
     let page: WhatsNewMessageViewModel.Page
+    let perform: (WhatsNewMessageViewModel.Action) -> Void
 
     var body: some View {
         GeometryReader { proxy in
@@ -97,7 +99,7 @@ private struct WhatsNewMessagePageView: View {
     @ViewBuilder
     private var action: some View {
         if let action = page.action {
-            WhatsNewActionView(action: action)
+            WhatsNewActionView(action: action) { perform(action) }
                 .padding(.horizontal, horizontalPadding)
                 .padding(.top, 16)
                 .padding(.bottom, 8)
@@ -111,12 +113,11 @@ private struct WhatsNewActionView: View {
     @EnvironmentObject private var theme: Theme
 
     let action: WhatsNewMessageViewModel.Action
+    let perform: () -> Void
 
     var body: some View {
-        Button(action.label) {
-            action.event.perform()
-        }
-        .buttonStyle(RoundedButtonStyle(theme: theme))
+        Button(action.label, action: perform)
+            .buttonStyle(RoundedButtonStyle(theme: theme))
     }
 }
 

--- a/podcasts/Whats New/Message/WhatsNewMessageViewController.swift
+++ b/podcasts/Whats New/Message/WhatsNewMessageViewController.swift
@@ -26,5 +26,7 @@ class WhatsNewMessageViewController: PCHostingController<WhatsNewMessageView> {
 
         title = viewModel.navigationTitle
         navigationItem.largeTitleDisplayMode = .never
+
+        viewModel.trackShown()
     }
 }

--- a/podcasts/Whats New/Message/WhatsNewMessageViewModel.swift
+++ b/podcasts/Whats New/Message/WhatsNewMessageViewModel.swift
@@ -87,6 +87,16 @@ final class WhatsNewMessageViewModel: ObservableObject {
         }
     }
 
+    func trackShown() {
+        Analytics.track(.whatsNewMessageShown, properties: analyticsProperties)
+    }
+
+    /// Does what a page's call to action asks, reporting the tap first.
+    func perform(_ action: Action) {
+        Analytics.track(.whatsNewActionTapped, properties: analyticsProperties.merging(["action": action.event.rawValue]) { $1 })
+        action.event.perform()
+    }
+
     /// Picks an answer, which nothing is told about until the reader continues.
     func select(_ option: WhatsNewPoll.Option) {
         guard !hasResponded else { return }
@@ -107,16 +117,19 @@ final class WhatsNewMessageViewModel: ObservableObject {
 
         hasResponded = true
 
-        Analytics.track(.whatsNewPollResponseSubmitted, properties: [
-            "message_uuid": messageID,
-            "message_type": messageType.rawValue,
+        Analytics.track(.whatsNewPollResponseSubmitted, properties: analyticsProperties.merging([
             "poll_uuid": research.poll.pollId,
             "poll_key": research.poll.pollKey,
             "option_uuid": option.id,
             "poll_option_key": option.pollOptionKey
-        ])
+        ]) { $1 })
 
         onRespond?(research.poll, option)
+    }
+
+    /// The properties every event about the message is reported with.
+    private var analyticsProperties: [String: String] {
+        ["message_uuid": messageID, "message_type": messageType.rawValue]
     }
 
     private var selectedOption: WhatsNewPoll.Option? {


### PR DESCRIPTION
| 📘 Part of: What's New Messages |
|:---:|

Fixes PCIOS-933

Adds the What's New feed events from [EventHorizonSchemas#131](https://github.com/Automattic/EventHorizonSchemas/pull/131), matching the Web Player ([PCWEB-777](https://linear.app/a8c/issue/PCWEB-777/add-whats-new-product-analytics)):

- `whats_new_feed_shown` – once per opening of the feed
- `whats_new_message_shown` – once per opening of a message (`message_uuid`, `message_type`)
- `whats_new_action_tapped` – before a page's action runs (`message_uuid`, `message_type`, `action`)
- `whats_new_read_all_tapped` – before "Read all" marks messages read

The poll response event now reuses the same message properties. `settings_general_whats_new_unread_dot_toggled` is left out: iOS has no unread-dot setting yet.

⚠️ Schema gaps: `whats_new_poll_response_submitted` isn't registered (web sends it too), and `whats_new_action_type` only lists `open_podcasts`, so the other six iOS actions report values outside the enum.

## To test

1. Enable the `whatsNewFeed` flag, run from Xcode, and filter the console for `🔵 Tracked`.
2. Go to Profile → **What's New**. `whats_new_feed_shown` is logged once.
3. Open **Introducing Playlists**. `whats_new_message_shown` is logged with its UUID and `new_feature`. Go back: no second `whats_new_feed_shown`.
4. Open it again, swipe to the page with a button and tap it. `whats_new_action_tapped` is logged with the action before the app navigates.
5. Open **Help shape the player**, pick an option and tap Continue. `whats_new_poll_response_submitted` still carries `message_uuid`, `message_type`, and the poll and option keys.
6. With unread messages left, tap **Read all**. `whats_new_read_all_tapped` is logged and the dots clear.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.